### PR TITLE
LPS-25892 Exception when undeploying some portlets

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/ListUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/ListUtil.java
@@ -181,13 +181,11 @@ public class ListUtil {
 	}
 
 	public static <E> boolean remove(List<E> list, E element) {
-		Iterator<E> itr = list.iterator();
-
-		while (itr.hasNext()) {
-			E curElement = itr.next();
+		for (int i = 0; i < list.size(); i++) {
+			E curElement = list.get(i);
 
 			if ((curElement == element) || curElement.equals(element)) {
-				itr.remove();
+				list.remove(i);
 
 				return true;
 			}


### PR DESCRIPTION
Hey Shuyang, Hugo told me to send you this first since it might be some performance thing?  Anyways, I was searching google and it seems like using a for loop is faster than using the iterator:
http://www.coderanch.com/t/202801/Performance/java/ArrayList-iterator-faster-than-looping

And it seems like it can handle any type of lists.  The current problem being CopyOnWriteArrayList because the iterator for this doesn't support remove.

Just wanted to check if using this for loop will hurt performance rather than using the iterator.  If it does, we can just do a instanceof check or something like that.  Either way, I don't think we use remove in many places and the lists aren't big enough for this to make any meaningful impact.
