### PR TITLE
LPS-31465

### DIFF
--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -607,7 +607,7 @@
 			<finder-column name="plid" />
 			<finder-column name="name" />
 		</finder>
-		<finder name="L_P_M" return-type="LayoutBranch">
+		<finder name="L_P_M" return-type="LayoutBranch" unique="true">
 			<finder-column name="layoutSetBranchId" />
 			<finder-column name="plid" />
 			<finder-column name="master" />
@@ -729,7 +729,7 @@
 			<finder-column name="parentLayoutRevisionId" />
 			<finder-column name="plid" />
 		</finder>
-		<finder name="L_H_P" return-type="LayoutRevision">
+		<finder name="L_H_P" return-type="LayoutRevision" unique="true">
 			<finder-column name="layoutSetBranchId" />
 			<finder-column name="head" />
 			<finder-column name="plid" />
@@ -919,7 +919,7 @@
 		<finder name="LtExpirationDate" return-type="Collection">
 			<finder-column name="expirationDate" comparator="&lt;" />
 		</finder>
-		<finder name="C_K" return-type="Lock">
+		<finder name="C_K" return-type="Lock" unique="true">
 			<finder-column name="className" />
 			<finder-column name="key" />
 		</finder>
@@ -1162,11 +1162,11 @@
 		<finder name="PasswordPolicyId" return-type="Collection">
 			<finder-column name="passwordPolicyId" />
 		</finder>
-		<finder name="C_C" return-type="PasswordPolicyRel">
+		<finder name="C_C" return-type="PasswordPolicyRel" unique="true">
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />
 		</finder>
-		<finder name="P_C_C" return-type="PasswordPolicyRel">
+		<finder name="P_C_C" return-type="PasswordPolicyRel" unique="true">
 			<finder-column name="passwordPolicyId" />
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />
@@ -1297,7 +1297,7 @@
 
 		<!-- Finder methods -->
 
-		<finder name="O_O" return-type="PortalPreferences">
+		<finder name="O_O" return-type="PortalPreferences" unique="true">
 			<finder-column name="ownerId" />
 			<finder-column name="ownerType" />
 		</finder>
@@ -1363,7 +1363,7 @@
 			<finder-column name="portletId" />
 			<finder-column name="classNameId" />
 		</finder>
-		<finder name="G_N_P_C" return-type="PortletItem">
+		<finder name="G_N_P_C" return-type="PortletItem" unique="true">
 			<finder-column name="groupId" />
 			<finder-column name="name" case-sensitive="false" />
 			<finder-column name="portletId" />
@@ -1694,7 +1694,7 @@
 			<finder-column name="roleId" arrayable-operator="OR" />
 			<finder-column name="actionIds" />
 		</finder>
-		<finder name="C_N_S_P_R_O_A" return-type="ResourcePermission">
+		<finder name="C_N_S_P_R_O_A" return-type="ResourcePermission" unique="true">
 			<finder-column name="companyId" />
 			<finder-column name="name" />
 			<finder-column name="scope" />
@@ -1841,7 +1841,7 @@
 		<finder name="Name" return-type="Shard">
 			<finder-column name="name" />
 		</finder>
-		<finder name="C_C" return-type="Shard">
+		<finder name="C_C" return-type="Shard" unique="true">
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />
 		</finder>
@@ -1963,7 +1963,7 @@
 
 		<!-- Finder methods -->
 
-		<finder name="Key" return-type="Ticket">
+		<finder name="Key" return-type="Ticket" unique="true">
 			<finder-column name="key" />
 		</finder>
 	</entity>
@@ -2440,7 +2440,7 @@
 			<finder-column name="workflowDefinitionName" />
 			<finder-column name="workflowDefinitionVersion" />
 		</finder>
-		<finder name="G_C_C_C_T" return-type="WorkflowDefinitionLink">
+		<finder name="G_C_C_C_T" return-type="WorkflowDefinitionLink" unique="true">
 			<finder-column name="groupId" />
 			<finder-column name="companyId" />
 			<finder-column name="classNameId" />

--- a/portal-impl/src/com/liferay/portlet/asset/service.xml
+++ b/portal-impl/src/com/liferay/portlet/asset/service.xml
@@ -298,7 +298,7 @@
 		<finder name="GroupId" return-type="Collection">
 			<finder-column name="groupId" />
 		</finder>
-		<finder name="G_N" return-type="AssetTag">
+		<finder name="G_N" return-type="AssetTag" unique="true">
 			<finder-column name="groupId" />
 			<finder-column name="name" />
 		</finder>

--- a/portal-impl/src/com/liferay/portlet/journal/service.xml
+++ b/portal-impl/src/com/liferay/portlet/journal/service.xml
@@ -418,7 +418,7 @@
 			<finder-column name="groupId" />
 			<finder-column name="parentFolderId" />
 		</finder>
-		<finder name="G_N" return-type="JournalFolder">
+		<finder name="G_N" return-type="JournalFolder" unique="true">
 			<finder-column name="groupId" />
 			<finder-column name="name" />
 		</finder>
@@ -539,7 +539,7 @@
 		<finder name="StructureId" return-type="Collection">
 			<finder-column name="structureId" />
 		</finder>
-		<finder name="SmallImageId" return-type="JournalTemplate">
+		<finder name="SmallImageId" return-type="JournalTemplate" unique="true">
 			<finder-column name="smallImageId" />
 		</finder>
 		<finder name="G_T" return-type="JournalTemplate" unique="true">

--- a/portal-impl/src/com/liferay/portlet/messageboards/service.xml
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service.xml
@@ -429,7 +429,7 @@
 		<finder name="GroupId" return-type="Collection" where="categoryId != -1">
 			<finder-column name="groupId" />
 		</finder>
-		<finder name="RootMessageId" return-type="MBMessage">
+		<finder name="RootMessageId" return-type="MBMessage" unique="true">
 			<finder-column name="rootMessageId" />
 		</finder>
 		<finder name="G_C" return-type="Collection">
@@ -500,7 +500,7 @@
 		<finder name="ThreadId" return-type="Collection">
 			<finder-column name="threadId" />
 		</finder>
-		<finder name="U_T" return-type="MBThreadFlag">
+		<finder name="U_T" return-type="MBThreadFlag" unique="true">
 			<finder-column name="userId" />
 			<finder-column name="threadId" />
 		</finder>

--- a/portal-impl/src/com/liferay/portlet/shopping/service.xml
+++ b/portal-impl/src/com/liferay/portlet/shopping/service.xml
@@ -189,13 +189,13 @@
 
 		<!-- Finder methods -->
 
-		<finder name="SmallImageId" return-type="ShoppingItem">
+		<finder name="SmallImageId" return-type="ShoppingItem" unique="true">
 			<finder-column name="smallImageId" />
 		</finder>
-		<finder name="MediumImageId" return-type="ShoppingItem">
+		<finder name="MediumImageId" return-type="ShoppingItem" unique="true">
 			<finder-column name="mediumImageId" />
 		</finder>
-		<finder name="LargeImageId" return-type="ShoppingItem">
+		<finder name="LargeImageId" return-type="ShoppingItem" unique="true">
 			<finder-column name="largeImageId" />
 		</finder>
 		<finder name="G_C" return-type="Collection">

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/service.xml
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/service.xml
@@ -184,13 +184,13 @@
 		<finder name="ProductEntryId" return-type="Collection">
 			<finder-column name="productEntryId" />
 		</finder>
-		<finder name="ThumbnailId" return-type="SCProductScreenshot">
+		<finder name="ThumbnailId" return-type="SCProductScreenshot" unique="true">
 			<finder-column name="thumbnailId" />
 		</finder>
-		<finder name="FullImageId" return-type="SCProductScreenshot">
+		<finder name="FullImageId" return-type="SCProductScreenshot" unique="true">
 			<finder-column name="fullImageId" />
 		</finder>
-		<finder name="P_P" return-type="SCProductScreenshot">
+		<finder name="P_P" return-type="SCProductScreenshot" unique="true">
 			<finder-column name="productEntryId" />
 			<finder-column name="priority" />
 		</finder>


### PR DESCRIPTION
There are 22 changes.
1. position: File: portal-trunk/portal-impl/src/com/liferay/portlet/asset/service.xml
                 Entity:"AssetTag"
                 Finder code:
                                        < finder name= "G_N" return-type = "AssetTag" >
                                              < finder-column name= "groupId" />
                                              < finder-column name= "name" />
                                       </ finder>
   
   reason:The name must be unique in a group.
2. position: File: portal-trunk/portal-impl/src/com/liferay/portlet/journal/service.xml
                 Entity: "JournalFolder"
                 Finder Code:
                                     < finder name= "G_N" return-type = "JournalFolder" >
                                          < finder-column name= "groupId" />
                                           < finder-column name= "name" />
                                     </ finder>  
   
   reason: Folder name is unique.
3.  position: File: portal-trunk/portal-impl/src/com/liferay/portlet/journal/service.xml
                  Entity: "JournalTemplate"
                  Finder Code:
                                       < finder name= "SmallImageId" return-type ="JournalTemplate"  >
                                            < finder-column name= "smallImageId" />
                                       </ finder> 
   
     reason: When they add a JournalTemplate,they'll use "counterLocalService.increment()" to create a smallImageId for it.
4. position: File: portal-trunk/portal-impl/src/com/liferay/portlet/messageboards/service.xml
                 Entity: ”MBThread“
                 Finder Code: 
                                        < finder name= "RootMessageId" return-type = "MBMessage" >
                                             < finder-column name= "rootMessageId" />
                                         </ finder>
   
    reason: In entity "MBMessage",rootMessageId have the "filter-primary='true'" attribute.
5. position:  File: portal-trunk/portal-impl/src/com/liferay/portlet/messageboards/service.xml
                  Entity: ”MBThreadFlag“
                  Finder Code: 
                                        < finder name= "U_T" return-type = "MBThreadFlag" >
                                             < finder-column name= "userId" />
                                             < finder-column name= "threadId" />
                                         </ finder>
   
    reason: When a user add a thread,it will create only one MBThrteadFlag.
6. position: File: portal-trunk/portal-impl/src/com/liferay/portlet/shopping/service.xml
                 Entity: "ShoppingItem"
                 Finder Code: 
                                      < finder name= "SmallImageId" return-type = "ShoppingItem" >
                                           < finder-column name= "smallImageId" />
                                      </ finder>
                                      < finder name= "MediumImageId" return-type = "ShoppingItem" >
                                            < finder-column name= "mediumImageId" />
                                      </ finder>
                                      < finder name= "LargeImageId" return-type = "ShoppingItem" >
                                             < finder-column name= "largeImageId" />
                                      </ finder>
   
   reason: When they add a ShoppingItem,they'll use "counterLocalService.increment()" to create SmallImageId,MediumImageId,LargeImageId for it.
7. position: File: portal-trunk/portal-impl/src/com/liferay/portlet/softwarecatalog/service.xml 
                 Entity: "SCProductScreenshot"
                 Finder Code: 
                                      < finder name= "ThumbnailId" return-type = "SCProductScreenshot" >
                                           < finder-column name= "thumbnailId" />
                                      </ finder>
                                      < finder name= "FullImageId" return-type = "SCProductScreenshot" >
                                           < finder-column name= "fullImageId" />
                                      </ finder> 
   
   reason: When they add a SCProductScreenshot, they'll use "counterLocalService.increment()" to create thumbnailId,fullImageId for it.
8. position: File: portal-trunk/portal-impl/src/com/liferay/portlet/softwarecatalog/service.xml 
                 Entity: "SCProductScreenshot"
                 Finder Code:
                                       < finder name= "P_P" return-type = "SCProductScreenshot" >
                                             < finder-column name= "productEntryId" />
                                             < finder-column name= "priority" />
                                       </ finder>
   
   reason:  ProductEntryId can point out the productEntry. If there are a lot of SCProductScreenshots in a productEntry,priority will distinguish them.
9. position: File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml  
                 Entity: "LayoutBranch"
                 Finder Code:  
                                       < finder name= "L_P_M" return-type = "LayoutBranch" >
                                            < finder-column name= "layoutSetBranchId" />
                                            < finder-column name= "plid" />
                                            < finder-column name= "master" />
                                      </ finder>                     
   
   reason: Plid is layout's primary key.In general,when we add a layout , a layoutBranch data will be created in database for it .Only when we select "content display page " as template for the layout,every layoutSetBranch will create one layoutBrach data,at that time ,layoutSetBranchId will distigunsh them. 
10. position:File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                   Entity: "LayoutRevision"
                   Finder Code: 
                                        < finder name= "L_H_P" return-type = "LayoutRevision" >
                                             < finder-column name= "layoutSetBranchId" />
                                             < finder-column name= "head" />
                                             < finder-column name= "plid" />
                                         </ finder>
    
    reason: Same reason with the above.
11. position:File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                   Entity: "Lock"
                   Finder code:
                                        < finder name= "C_K" return-type = "Lock" >
                                              < finder-column name= "className" />
                                              < finder-column name= "key" />
                                         </ finder>
    
       reason: ClassName shows what model the locked entity is,and the key is entity's primary key.Such as document library portlet,when we locked a document,the className is documentlibrary.model.DLFileEntry,and the key is fileEntryId.
12. position: File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                    Entity: "passwordPolicyRel"
                    Finder code:
                                        < finder name= "C_C" return-type = "PasswordPolicyRel" >
                                              < finder-column name= "classNameId" />
                                              < finder-column name= "classPK" />
                                         </ finder>
    
     reason: The classNameId shows what member added this passwordPolicy,and classPk is this member's primary key.
                    Such as ,if we assign a passwordPolicy to a user,the classNameId will point out the mode is user,and classPK is userId.If we add a passwordPolicy to a user who has already added one,it will not create a new data in passwordPolicayRel table.
13. position: File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                    Entity: "PasswordPolicyRel"
                    Finder code:
                                        < finder name= "P_C_C" return-type = "PasswordPolicyRel" >
                                              < finder-column name= "passwordPolicyId" />
                                              < finder-column name= "classNameId" />
                                              < finder-column name= "classPK" />
                                       </ finder>
    
     reason: Same reason with the above.
14. position: File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                    Entity: "PortalPreferences"
                    Finder code:
                                        < finder name= "O_O" return-type = "PortalPreferences" >
                                              < finder-column name= "ownerId" />
                                              < finder-column name= "ownerType" />
                                         </ finder>
    
       reason: The ownerType shows what  type the owner is, and the ownerId is when the type is that ,it's primary key.
                  Such as when ownerType = 1,the type is company,and the ownerId will be companyId at that time.
15. position: File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                    Entity: "PortletItem"
                    Finder code:
                                       < finder name= "G_N_P_C" return-type = "PortletItem" >
                                              < finder-column name= "groupId" />
                                              < finder-column name= "name" case-sensitive = "false" />
                                              < finder-column name= "portletId" />
                                              < finder-column name= "classNameId" />
                                       </ finder> 
    
     reason: In the same group,the portletItem name can't be reduplicate in a portlet .
16. position: File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                    Entity: "ResourcePermission"
                    Finder code: 
                                        < finder name= "C_N_S_P_R_O_A" return-type = "ResourcePermission" >
                                              < finder-column name= "companyId" />
                                              < finder-column name= "name" />
                                              < finder-column name= "scope" />
                                              < finder-column name= "primKey" />
                                              < finder-column name= "roleId" />
                                              < finder-column name= "ownerId" />
                                              < finder-column name= "actionIds" />
                                       </ finder>
    
    reason: RoleId would point out what role you added the permission for.the Name is the added permission's name.
17. position: File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                    Entity: "Shard"
                    Finder code: 
                                        < finder name= "C_C" return-type = "Shard" >
                                              < finder-column name= "classNameId" />
                                              < finder-column name= "classPK" />
                                         </ finder>
    
     reason: the classNameId shows the type of the mode,and the classPK is the mode's primary key.
18. position: File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                    Entity: "Ticket"
                    Finder code: 
                                        < finder name= "Key" return-type = "Ticket">
                                              < finder-column name= "key" />
                                        </ finder>
    
     reason: The key is created by ”PortalUUIDUtil.generate()“ when we add a ticket.
19. position: File: portal-trunk/portal-impl/src/com/liferay/portal/service.xml
                    Entity: "WorkflowDefinitionLink"
                    Finder code:
                                        < finder name= "G_C_C_C_T" return-type = "WorkflowDefinitionLink" >
                                              < finder-column name= "groupId" />
                                              < finder-column name= "companyId" />
                                              < finder-column name= "classNameId" />
                                              < finder-column name= "classPK" />
                                              < finder-column name= "typePK" />
                                          </ finder>
    
     reason: ClassNameId shows which class mode used the workflow,and it can't be reduplicate.
