### PR TITLE
LPS-29174 fix sample-sql-builder ftl

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/samplesqlbuilder/dependencies/mb_category.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/samplesqlbuilder/dependencies/mb_category.ftl
@@ -1,6 +1,6 @@
 <#setting number_format = "0">
 
-insert into MBCategory values ('${portalUUIDUtil.generate()}', ${mbCategory.categoryId}, ${mbCategory.groupId}, ${mbCategory.companyId}, ${mbCategory.userId}, '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0, '${mbCategory.name}', '${mbCategory.description}', '${mbCategory.displayStyle}', ${mbCategory.threadCount}, ${mbCategory.messageCount}, CURRENT_TIMESTAMP);
+insert into MBCategory values ('${portalUUIDUtil.generate()}', ${mbCategory.categoryId}, ${mbCategory.groupId}, ${mbCategory.companyId}, ${mbCategory.userId}, '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0, '${mbCategory.name}', '${mbCategory.description}', '${mbCategory.displayStyle}', ${mbCategory.threadCount}, ${mbCategory.messageCount}, CURRENT_TIMESTAMP, 0, ${mbCategory.userId}, '', CURRENT_TIMESTAMP);
 
 <#if (mbCategory.categoryId != 0)>
 	insert into MBMailingList values ('${portalUUIDUtil.generate()}', ${counter.get()}, ${mbCategory.groupId}, ${companyId}, ${mbCategory.userId}, '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ${mbCategory.categoryId}, '', 'pop3', '', 110, FALSE, '', '', 5, '', FALSE, '', 25, FALSE, '', '', FALSE, FALSE);


### PR DESCRIPTION
Hi Shuyang,

Update mb_category.ftl according to the changes in LPS-29174 (Recycle Bin for MB Category Views).

I made this change according to the similar insert statement of mbThread in mb.ftl, but there is one place I am not sure -- I am currently using ${mbCategory.userId} as the data of the statusByUserId column since there is no "mbThread.lastPostByUserId" like thing in mbCategory model.

Now I have used this ftl to rebuild the database and run the test. It works normally.

Dante
