### PR TITLE
LPS-33447 Fix LuceneHelperImplTest on windows.

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/search/lucene/LuceneHelperImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/search/lucene/LuceneHelperImplTest.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
-import com.liferay.portal.kernel.util.SocketUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
@@ -60,8 +59,6 @@ import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-
-import java.nio.channels.ServerSocketChannel;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -832,11 +829,19 @@ public class LuceneHelperImplTest {
 	private class MockServer extends Thread {
 
 		public MockServer() throws IOException {
-			ServerSocketChannel serverSocketChannel =
-				SocketUtil.createServerSocketChannel(
-					_localhostInetAddress, 1024, null);
+			int port = 1024;
 
-			_serverSocket = serverSocketChannel.socket();
+			while (true) {
+				try {
+					_serverSocket = new ServerSocket(
+						port, 1, _localhostInetAddress);
+
+					break;
+				}
+				catch (IOException ioe) {
+					port++;
+				}
+			}
 		}
 
 		public int getPort() {


### PR DESCRIPTION
Hi Shuyang,

This problem may cause by client and server are using different socket framework, like server part is using nio, but client not. Then my fix is to change server part using old socket framework instead of nio.

I did not find the root reason of it, but I think this fix makes sense.

Tina.
