### PR TITLE
Lps 37367 Fix SampleSQLBuilder

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/samplesqlbuilder/DataFactory.java
+++ b/portal-impl/src/com/liferay/portal/tools/samplesqlbuilder/DataFactory.java
@@ -2249,6 +2249,9 @@ public class DataFactory {
 		group.setTreePath(
 			StringPool.SLASH + group.getGroupId() + StringPool.SLASH);
 		group.setName(name);
+		group.setManualMembership(true);
+		group.setMembershipRestriction(
+			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION);
 		group.setFriendlyURL(
 			StringPool.FORWARD_SLASH +
 				FriendlyURLNormalizerUtil.normalize(name));

--- a/portal-impl/src/com/liferay/portal/tools/samplesqlbuilder/dependencies/macro.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/samplesqlbuilder/dependencies/macro.ftl
@@ -135,7 +135,7 @@
 	_group
 	_publicPageCount
 >
-	insert into Group_ values ('${_group.uuid}', ${_group.groupId}, ${_group.companyId}, ${_group.creatorUserId}, ${_group.classNameId}, ${_group.classPK}, ${_group.parentGroupId}, ${_group.liveGroupId}, '${_group.treePath}', '${_group.name}', '${_group.description}', ${_group.type}, '${_group.typeSettings}', '${_group.friendlyURL}', ${_group.site?string}, ${_group.active?string});
+	insert into Group_ values ('${_group.uuid}', ${_group.groupId}, ${_group.companyId}, ${_group.creatorUserId}, ${_group.classNameId}, ${_group.classPK}, ${_group.parentGroupId}, ${_group.liveGroupId}, '${_group.treePath}', '${_group.name}', '${_group.description}', ${_group.type}, '${_group.typeSettings}', ${_group.manualMembership?string}, ${_group.membershipRestriction}, '${_group.friendlyURL}', ${_group.site?string}, ${_group.active?string});
 
 	<#local layoutSets = dataFactory.newLayoutSets(_group.groupId, _publicPageCount)>
 


### PR DESCRIPTION
Hi Shuyang,

There are two regression bugs in SampleSQLBuilder. I have something to say about the first one.

The first commit fixed the bug caused by LPS-36001. The root reason of this problem is ClassNameLocalServiceUtil is called when running SampleSQLBuilder but it is not initialized, there are two solutions:

1) Initialize ClassNameLocalServiceUtil properly, it means need to add "portal-spring.xml" and other files it depends to spring initialization.
2) Use _**ModelImpl instead of *_*Impl in DataFactory to avoid the invoke of ClassNameLocalServiceUtil.

I chose 2), for we talked before, in DataFactory, it should use _**ModelImpl instead of *_*Impl, and also 1) will slow down SampleSQLBuilder.

Let me know if you have any questions about it.

Thanks.
Tina.
