### PR TITLE
[Tech Support] LPS-39073

### DIFF
--- a/portal-impl/src/com/liferay/portal/cache/ehcache/EhcacheStreamBootstrapHelpUtil.java
+++ b/portal-impl/src/com/liferay/portal/cache/ehcache/EhcacheStreamBootstrapHelpUtil.java
@@ -299,6 +299,16 @@ public class EhcacheStreamBootstrapHelpUtil {
 
 						Element element = ehcache.get(key);
 
+						if (element == null) {
+							if (_log.isDebugEnabled()) {
+								_log.debug(
+									"Element for key " + key +
+										" is not available or has expired");
+							}
+
+							continue;
+						}
+
 						Object value = element.getObjectValue();
 
 						if (!(value instanceof Serializable)) {


### PR DESCRIPTION
Hi Shuyang,

This should be an easy one as I'm only adding a null check. I'm not even sure if we need the log message there.

However, there seems to be another issue with the new bootstrap loader that we'll probably want to address. We're firing a multicast request to all the cluster nodes which will in turn make them open a socket to connect to. But since we're only connecting to one of the nodes, you'll see a socket timeout exception for each EhcacheStreamServerThread on the other nodes. Do you think we should rather go for unicast in this case and contact a random node to fetch the cache from?

Thanks already,
Daniel
