### PR TITLE
LPS-40207 Modify logic in LayoutStagingImpl.isBranchingLayoutSet() to shortcut heavy operations.

### DIFF
--- a/portal-impl/src/com/liferay/portal/staging/LayoutStagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/LayoutStagingImpl.java
@@ -117,6 +117,10 @@ public class LayoutStagingImpl implements LayoutStaging {
 		UnicodeProperties typeSettingsProperties =
 			group.getTypeSettingsProperties();
 
+		if (typeSettingsProperties.isEmpty()) {
+			return false;
+		}
+
 		boolean branchingEnabled = false;
 
 		if (privateLayout) {
@@ -128,8 +132,8 @@ public class LayoutStagingImpl implements LayoutStaging {
 				typeSettingsProperties.getProperty("branchingPublic"));
 		}
 
-		if (group.isStaged() && branchingEnabled) {
-			if (!group.isStagedRemotely() && !isStagingGroup) {
+		if (branchingEnabled && group.isStaged()) {
+			if (!isStagingGroup && !group.isStagedRemotely()) {
 				return false;
 			}
 


### PR DESCRIPTION
Hi Shuyang,

According to profile, com.liferay.portal.model.impl.GroupImpl.isStaged is invoked many times which should be skipped when staging is disabled. 

Thanks.
Tina.
