### PR TITLE
LPS-40315 Use overloading instead of checking class type

### DIFF
--- a/util-taglib/src/com/liferay/taglib/util/AttributesTagSupport.java
+++ b/util-taglib/src/com/liferay/taglib/util/AttributesTagSupport.java
@@ -62,14 +62,19 @@ public class AttributesTagSupport
 	}
 
 	public void setNamespacedAttribute(
-		HttpServletRequest request, String key, Object value) {
+		HttpServletRequest request, String key, Boolean value) {
 
-		if (value instanceof Boolean) {
-			value = String.valueOf(value);
-		}
-		else if (value instanceof Number) {
-			value = String.valueOf(value);
-		}
+		request.setAttribute(_encodeKey(key), String.valueOf(value));
+	}
+
+	public void setNamespacedAttribute(
+		HttpServletRequest request, String key, Number value) {
+
+		request.setAttribute(_encodeKey(key), String.valueOf(value));
+	}
+
+	public void setNamespacedAttribute(
+		HttpServletRequest request, String key, Object value) {
 
 		request.setAttribute(_encodeKey(key), value);
 	}


### PR DESCRIPTION
Hi Shuyang.

According to profile, most time(more than 80%) the "value" passed in is not neither Boolean nor Number, so I changed it to use overloading instead of checking class type every time.

Thanks.
Tina.
