### PR TITLE
LPS-40317 Use GroupPermissionUtil.contains(PermissionChecker, Group, String) instead of GroupPermissionUtil.contains(PermissionChecker, long, String)

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -412,8 +412,7 @@ public class ServicePreAction extends Action {
 			boolean viewableStaging =
 				!group.isControlPanel() &&
 				GroupPermissionUtil.contains(
-					permissionChecker, group.getGroupId(),
-					ActionKeys.VIEW_STAGING);
+					permissionChecker, group, ActionKeys.VIEW_STAGING);
 
 			if (viewableStaging) {
 				layouts = LayoutLocalServiceUtil.getLayouts(
@@ -1050,23 +1049,34 @@ public class ServicePreAction extends Action {
 				}
 			}
 
-			boolean hasAddLayoutGroupPermission = GroupPermissionUtil.contains(
-				permissionChecker, scopeGroupId, ActionKeys.ADD_LAYOUT);
 			boolean hasAddLayoutLayoutPermission =
 				!layout.isTypeControlPanel() &&
 				LayoutPermissionUtil.contains(
 					permissionChecker, layout, ActionKeys.ADD_LAYOUT);
-			boolean hasManageLayoutsGroupPermission =
-				GroupPermissionUtil.contains(
-					permissionChecker, scopeGroupId, ActionKeys.MANAGE_LAYOUTS);
-			boolean hasManageStagingPermission = GroupPermissionUtil.contains(
-				permissionChecker, scopeGroupId, ActionKeys.MANAGE_STAGING);
-			boolean hasPublishStagingPermission = GroupPermissionUtil.contains(
-				permissionChecker, scopeGroupId, ActionKeys.PUBLISH_STAGING);
-			boolean hasUpdateGroupPermission = GroupPermissionUtil.contains(
-				permissionChecker, scopeGroupId, ActionKeys.UPDATE);
-			boolean hasViewStagingPermission = GroupPermissionUtil.contains(
-				permissionChecker, scopeGroupId, ActionKeys.VIEW_STAGING);
+
+			boolean hasAddLayoutGroupPermission = false;
+			boolean hasManageLayoutsGroupPermission = false;
+			boolean hasManageStagingPermission = false;
+			boolean hasPublishStagingPermission = false;
+			boolean hasUpdateGroupPermission = false;
+			boolean hasViewStagingPermission = false;
+
+			if (scopeGroupId > 0) {
+				Group scopeGroup = GroupLocalServiceUtil.getGroup(scopeGroupId);
+
+				hasAddLayoutGroupPermission = GroupPermissionUtil.contains(
+					permissionChecker, scopeGroup, ActionKeys.ADD_LAYOUT);
+				hasManageLayoutsGroupPermission = GroupPermissionUtil.contains(
+					permissionChecker, scopeGroup, ActionKeys.MANAGE_LAYOUTS);
+				hasManageStagingPermission = GroupPermissionUtil.contains(
+					permissionChecker, scopeGroup, ActionKeys.MANAGE_STAGING);
+				hasPublishStagingPermission = GroupPermissionUtil.contains(
+					permissionChecker, scopeGroup, ActionKeys.PUBLISH_STAGING);
+				hasUpdateGroupPermission = GroupPermissionUtil.contains(
+					permissionChecker, scopeGroup, ActionKeys.UPDATE);
+				hasViewStagingPermission = GroupPermissionUtil.contains(
+					permissionChecker, scopeGroup, ActionKeys.VIEW_STAGING);
+			}
 
 			if (!group.isControlPanel() && !group.isUser() &&
 				!group.isUserGroup() && hasUpdateGroupPermission) {
@@ -1762,8 +1772,7 @@ public class ServicePreAction extends Action {
 			(group.isStagingGroup() || group.isStagedRemotely()) &&
 			 !group.isControlPanel() &&
 			 GroupPermissionUtil.contains(
-				 permissionChecker, group.getGroupId(),
-				 ActionKeys.VIEW_STAGING);
+				 permissionChecker, group, ActionKeys.VIEW_STAGING);
 
 		if (hasAccessPermission(
 				permissionChecker, layout, doAsGroupId, controlPanelCategory,
@@ -1838,7 +1847,7 @@ public class ServicePreAction extends Action {
 				}
 
 				if (GroupPermissionUtil.contains(
-						permissionChecker, group.getGroupId(),
+						permissionChecker, group,
 						ActionKeys.VIEW_SITE_ADMINISTRATION)) {
 
 					return true;

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
@@ -1203,8 +1203,7 @@ public class GroupServiceImpl extends GroupServiceBaseImpl {
 
 		for (Group group : groups) {
 			if (GroupPermissionUtil.contains(
-					getPermissionChecker(), group.getGroupId(),
-					ActionKeys.VIEW)) {
+					getPermissionChecker(), group, ActionKeys.VIEW)) {
 
 				filteredGroups.add(group);
 			}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -2216,8 +2216,7 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 
 				if (!ArrayUtil.contains(groupIds, group.getGroupId()) &&
 					(!GroupPermissionUtil.contains(
-						permissionChecker, group.getGroupId(),
-						ActionKeys.ASSIGN_MEMBERS) ||
+						permissionChecker, group, ActionKeys.ASSIGN_MEMBERS) ||
 					 SiteMembershipPolicyUtil.isMembershipProtected(
 						 permissionChecker, user.getUserId(),
 						 group.getGroupId()) ||

--- a/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
@@ -252,16 +252,14 @@ public class LayoutPermissionImpl implements LayoutPermission {
 			}
 
 			if (GroupPermissionUtil.contains(
-					permissionChecker, layout.getGroupId(),
-					ActionKeys.ADD_LAYOUT)) {
+					permissionChecker, group, ActionKeys.ADD_LAYOUT)) {
 
 				return true;
 			}
 		}
 
 		if (GroupPermissionUtil.contains(
-				permissionChecker, layout.getGroupId(),
-				ActionKeys.MANAGE_LAYOUTS)) {
+				permissionChecker, group, ActionKeys.MANAGE_LAYOUTS)) {
 
 			return true;
 		}
@@ -417,8 +415,7 @@ public class LayoutPermissionImpl implements LayoutPermission {
 
 			if (layout.isPrivateLayout()) {
 				if (GroupPermissionUtil.contains(
-						permissionChecker, groupUser.getGroupId(),
-						ActionKeys.MANAGE_LAYOUTS) ||
+						permissionChecker, group, ActionKeys.MANAGE_LAYOUTS) ||
 					UserPermissionUtil.contains(
 						permissionChecker, groupUserId,
 						groupUser.getOrganizationIds(), ActionKeys.UPDATE)) {
@@ -435,8 +432,7 @@ public class LayoutPermissionImpl implements LayoutPermission {
 
 		if (group.isStagingGroup()) {
 			if (GroupPermissionUtil.contains(
-					permissionChecker, group.getGroupId(),
-					ActionKeys.VIEW_STAGING)) {
+					permissionChecker, group, ActionKeys.VIEW_STAGING)) {
 
 				return true;
 			}
@@ -449,10 +445,9 @@ public class LayoutPermissionImpl implements LayoutPermission {
 
 		if (group.isSite()) {
 			if (GroupPermissionUtil.contains(
-					permissionChecker, group.getGroupId(),
-					ActionKeys.MANAGE_LAYOUTS) ||
+					permissionChecker, group, ActionKeys.MANAGE_LAYOUTS) ||
 				GroupPermissionUtil.contains(
-					permissionChecker, group.getGroupId(), ActionKeys.UPDATE)) {
+					permissionChecker, group, ActionKeys.UPDATE)) {
 
 				return true;
 			}

--- a/portal-impl/src/com/liferay/portal/service/permission/UserGroupRolePermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/UserGroupRolePermissionImpl.java
@@ -61,7 +61,7 @@ public class UserGroupRolePermissionImpl implements UserGroupRolePermission {
 
 		if (permissionChecker.isGroupOwner(groupId) ||
 			GroupPermissionUtil.contains(
-				permissionChecker, groupId, ActionKeys.ASSIGN_USER_ROLES) ||
+				permissionChecker, group, ActionKeys.ASSIGN_USER_ROLES) ||
 			OrganizationPermissionUtil.contains(
 				permissionChecker, group.getOrganizationId(),
 				ActionKeys.ASSIGN_USER_ROLES) ||

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -1754,8 +1754,7 @@ public class StagingImpl implements Staging {
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
 		if (!GroupPermissionUtil.contains(
-				permissionChecker, liveGroup.getGroupId(),
-				ActionKeys.MANAGE_STAGING)) {
+				permissionChecker, liveGroup, ActionKeys.MANAGE_STAGING)) {
 
 			return;
 		}

--- a/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherImpl.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherImpl.java
@@ -988,7 +988,7 @@ public class AssetPublisherImpl implements AssetPublisher {
 			}
 
 			return GroupPermissionUtil.contains(
-				permissionChecker, groupId, ActionKeys.UPDATE);
+				permissionChecker, group, ActionKeys.UPDATE);
 		}
 		else if (groupId != companyGroupId) {
 			return GroupPermissionUtil.contains(

--- a/portal-impl/src/com/liferay/portlet/grouppages/GroupPagesControlPanelEntry.java
+++ b/portal-impl/src/com/liferay/portlet/grouppages/GroupPagesControlPanelEntry.java
@@ -41,7 +41,7 @@ public class GroupPagesControlPanelEntry extends BaseControlPanelEntry {
 		throws Exception {
 
 		return GroupPermissionUtil.contains(
-			permissionChecker, group.getGroupId(), ActionKeys.MANAGE_LAYOUTS);
+			permissionChecker, group, ActionKeys.MANAGE_LAYOUTS);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
@@ -414,8 +414,7 @@ public class EditLayoutsAction extends PortletAction {
 
 			if (parentPlid == LayoutConstants.DEFAULT_PARENT_LAYOUT_ID) {
 				if (!GroupPermissionUtil.contains(
-						permissionChecker, group.getGroupId(),
-						ActionKeys.ADD_LAYOUT)) {
+						permissionChecker, group, ActionKeys.ADD_LAYOUT)) {
 
 					throw new PrincipalException();
 				}
@@ -478,8 +477,7 @@ public class EditLayoutsAction extends PortletAction {
 
 			if (group.isCompany() || group.isSite()) {
 				boolean publishToLive = GroupPermissionUtil.contains(
-					permissionChecker, group.getGroupId(),
-					ActionKeys.PUBLISH_STAGING);
+					permissionChecker, group, ActionKeys.PUBLISH_STAGING);
 
 				if (!hasUpdateLayoutPermission && !publishToLive) {
 					throw new PrincipalException();

--- a/portal-impl/src/com/liferay/portlet/rolesadmin/action/ActionUtil.java
+++ b/portal-impl/src/com/liferay/portlet/rolesadmin/action/ActionUtil.java
@@ -69,7 +69,7 @@ public class ActionUtil {
 				long organizationGroupId = organizationGroup.getGroupId();
 
 				if (GroupPermissionUtil.contains(
-						permissionChecker, organizationGroupId,
+						permissionChecker, organizationGroup,
 						ActionKeys.ASSIGN_USER_ROLES) ||
 					OrganizationPermissionUtil.contains(
 						permissionChecker, organizationId,
@@ -97,8 +97,7 @@ public class ActionUtil {
 		}
 		else if ((group != null) && group.isRegularSite()) {
 			if (GroupPermissionUtil.contains(
-					permissionChecker, group.getGroupId(),
-					ActionKeys.ASSIGN_USER_ROLES) ||
+					permissionChecker, group, ActionKeys.ASSIGN_USER_ROLES) ||
 				UserGroupRoleLocalServiceUtil.hasUserGroupRole(
 					themeDisplay.getUserId(), group.getGroupId(),
 					RoleConstants.SITE_ADMINISTRATOR, true) ||

--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -496,9 +496,9 @@ public class SitesImpl implements Sites {
 
 		if (group.isStagingGroup() &&
 			!GroupPermissionUtil.contains(
-				permissionChecker, groupId, ActionKeys.MANAGE_STAGING) &&
+				permissionChecker, group, ActionKeys.MANAGE_STAGING) &&
 			!GroupPermissionUtil.contains(
-				permissionChecker, groupId, ActionKeys.PUBLISH_STAGING)) {
+				permissionChecker, group, ActionKeys.PUBLISH_STAGING)) {
 
 			throw new PrincipalException();
 		}
@@ -1084,8 +1084,7 @@ public class SitesImpl implements Sites {
 		}
 
 		if (GroupPermissionUtil.contains(
-				permissionChecker, userGroupGroup.getGroupId(),
-				ActionKeys.VIEW)) {
+				permissionChecker, userGroupGroup, ActionKeys.VIEW)) {
 
 			return true;
 		}

--- a/portal-impl/src/com/liferay/portlet/sitesadmin/SiteMembershipsControlPanelEntry.java
+++ b/portal-impl/src/com/liferay/portlet/sitesadmin/SiteMembershipsControlPanelEntry.java
@@ -47,8 +47,7 @@ public class SiteMembershipsControlPanelEntry extends BaseControlPanelEntry {
 		throws Exception {
 
 		if (GroupPermissionUtil.contains(
-				permissionChecker, group.getGroupId(),
-				ActionKeys.ASSIGN_MEMBERS)) {
+				permissionChecker, group, ActionKeys.ASSIGN_MEMBERS)) {
 
 			return true;
 		}

--- a/portal-impl/src/com/liferay/portlet/sitesadmin/SiteSettingsControlPanelEntry.java
+++ b/portal-impl/src/com/liferay/portlet/sitesadmin/SiteSettingsControlPanelEntry.java
@@ -34,7 +34,7 @@ public class SiteSettingsControlPanelEntry extends BaseControlPanelEntry {
 
 		if (group.isUser() || group.isLayoutSetPrototype() ||
 			!GroupPermissionUtil.contains(
-				permissionChecker, group.getGroupId(), ActionKeys.UPDATE)) {
+				permissionChecker, group, ActionKeys.UPDATE)) {
 
 			return true;
 		}

--- a/portal-impl/src/com/liferay/portlet/sitesadmin/SiteTeamsControlPanelEntry.java
+++ b/portal-impl/src/com/liferay/portlet/sitesadmin/SiteTeamsControlPanelEntry.java
@@ -46,8 +46,7 @@ public class SiteTeamsControlPanelEntry extends BaseControlPanelEntry {
 		throws Exception {
 
 		if (GroupPermissionUtil.contains(
-				permissionChecker, group.getGroupId(),
-				ActionKeys.MANAGE_TEAMS)) {
+				permissionChecker, group, ActionKeys.MANAGE_TEAMS)) {
 
 			return true;
 		}

--- a/portal-impl/src/com/liferay/portlet/usersadmin/action/EditOrganizationAction.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/action/EditOrganizationAction.java
@@ -275,8 +275,8 @@ public class EditOrganizationAction extends PortletAction {
 		Group organizationGroup = organization.getGroup();
 
 		if (GroupPermissionUtil.contains(
-				themeDisplay.getPermissionChecker(),
-				organizationGroup.getGroupId(), ActionKeys.UPDATE)) {
+				themeDisplay.getPermissionChecker(), organizationGroup,
+				ActionKeys.UPDATE)) {
 
 			SitesUtil.updateLayoutSetPrototypesLinks(
 				organizationGroup, publicLayoutSetPrototypeId,

--- a/portal-impl/src/com/liferay/portlet/usersadmin/util/UsersAdminImpl.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/util/UsersAdminImpl.java
@@ -234,7 +234,7 @@ public class UsersAdminImpl implements UsersAdmin {
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
 
 		if (GroupPermissionUtil.contains(
-				permissionChecker, groupId, ActionKeys.ASSIGN_USER_ROLES) ||
+				permissionChecker, group, ActionKeys.ASSIGN_USER_ROLES) ||
 			OrganizationPermissionUtil.contains(
 				permissionChecker, group.getOrganizationId(),
 				ActionKeys.ASSIGN_USER_ROLES)) {
@@ -275,8 +275,7 @@ public class UsersAdminImpl implements UsersAdmin {
 			Group group = itr.next();
 
 			if (!GroupPermissionUtil.contains(
-					permissionChecker, group.getGroupId(),
-					ActionKeys.ASSIGN_MEMBERS)) {
+					permissionChecker, group, ActionKeys.ASSIGN_MEMBERS)) {
 
 				itr.remove();
 			}


### PR DESCRIPTION
Hi Shuyang,

According to profile, we are invoking GroupPermissionUtil.contains(PermissionChecker, long, String) many times which can be replaced by simpler GroupPermissionUtil.contains(PermissionChecker, Group, String).

Then I made this change, in this commit, it only includes changes in portal-impl, I will sent another pr for the changes in portal-web.

Thanks.
Tina.
