### PR TITLE
LPS-43568 HttpSessionWrapper needs hashCode and equals to make sure it does not hide internal session comparison.

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/servlet/HttpSessionWrapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/HttpSessionWrapper.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.servlet;
 
+import com.liferay.portal.kernel.util.Validator;
+
 import java.util.Enumeration;
 
 import javax.servlet.ServletContext;
@@ -26,6 +28,25 @@ public class HttpSessionWrapper implements HttpSession {
 
 	public HttpSessionWrapper(HttpSession session) {
 		_session = session;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof HttpSessionWrapper)) {
+			return false;
+		}
+
+		HttpSessionWrapper httpSessionWrapper = (HttpSessionWrapper)obj;
+
+		if (Validator.equals(_session, httpSessionWrapper._session)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override
@@ -92,6 +113,11 @@ public class HttpSessionWrapper implements HttpSession {
 
 	public HttpSession getWrappedSession() {
 		return _session;
+	}
+
+	@Override
+	public int hashCode() {
+		return _session.hashCode();
 	}
 
 	@Override


### PR DESCRIPTION
Hey Shuyang,

The solution is to compare physically instead of comparing Id, it is safe to do this, since we can not reproduce the client problem(different session instances with same sessionId) on weblogic, then we are not sure if the content is same or not.

Thanks.
Tina.
