### PR TITLE
[TECH SUPPORT] LPS-45822 MetaInfoCacheServletResponse doesn't keep original response status

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/servlet/MetaInfoCacheServletResponse.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/MetaInfoCacheServletResponse.java
@@ -104,6 +104,8 @@ public class MetaInfoCacheServletResponse extends HttpServletResponseWrapper {
 
 	public MetaInfoCacheServletResponse(HttpServletResponse response) {
 		super(response);
+
+		setStatus(response.getStatus());
 	}
 
 	@Override


### PR DESCRIPTION
Hi Shuyang,

This pull request is rather a question with a proposed idea. Don't you think we should keep the status of the original response when a new MetaInfoCacheServletResponse is created?

In my use case ETagFilter creates a RestrictedByteBufferCacheServletResponse which is a MetaInfoCacheServletResponse. MetaInfoCacheServletResponse overrides the getStatus() method to get the status from the metaData (which is initialized with SC_OK status). Therefore if you have Service Event Hook (please see an example on the LPS) or any code which wants to know the status, it will see as SC_OK, not the right value (in my case it is SC_NOT_FOUND). Do you consider this as a bug? If so, don't you think we should keep other metaData from the original response, too? I haven't modified other parts of the metadata since I'm not event sure the default value of the status field is treated as a bug.

For exact reproduction steps, please see LPS-45822.

Thanks,
Ákos
