### PR TITLE
LPS-45936 Companies stored in a non default shard are not initialized properly on startup

### DIFF
--- a/portal-service/src/com/liferay/portal/security/auth/CompanyThreadLocal.java
+++ b/portal-service/src/com/liferay/portal/security/auth/CompanyThreadLocal.java
@@ -51,18 +51,22 @@ public class CompanyThreadLocal {
 			_log.debug("setCompanyId " + companyId);
 		}
 
+		Long currentCompanyId = _companyId.get();
+
 		if (companyId > 0) {
 			try {
+				_companyId.set(companyId);
+
 				Company company = CompanyLocalServiceUtil.getCompany(companyId);
 
 				LocaleThreadLocal.setDefaultLocale(company.getLocale());
 				TimeZoneThreadLocal.setDefaultTimeZone(company.getTimeZone());
 			}
 			catch (Exception e) {
+				_companyId.set(currentCompanyId);
+
 				_log.error(e, e);
 			}
-
-			_companyId.set(companyId);
 		}
 		else {
 			LocaleThreadLocal.setDefaultLocale(null);


### PR DESCRIPTION
Hi @shuyangzhou,

The method com.liferay.portal.dao.shard.advice.ShardPersistenceAdvice uses the variable companyId from CompanyThreadLocal.getCompanyId to know the company we are currently in (shardAdvice.setShardNameByCompany()). But during the logic of CompanyThreadLocal.setCompanyId(companyId) that variable hasn't been initialized yet and the previous exception is displayed (see LPS-45936 for more information)

This causes that companies belong to non default shards aren't initialized properly (method com.liferay.portal.util.PortalInstances._initCompany)

Thanks.

PD: @migue
