### PR TITLE
LPS-46104

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/MVCCSynchronizerPostUpdateEventListener.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/MVCCSynchronizerPostUpdateEventListener.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.dao.orm.hibernate.event;
 
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
+import com.liferay.portal.kernel.dao.shard.ShardUtil;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.model.MVCCModel;
 
@@ -37,9 +38,23 @@ public class MVCCSynchronizerPostUpdateEventListener
 		if (entity instanceof MVCCModel) {
 			BaseModel<?> baseModel = (BaseModel<?>)entity;
 
-			EntityCacheUtil.putResult(
-				baseModel.isEntityCacheEnabled(), entity.getClass(),
-				baseModel.getPrimaryKeyObj(), baseModel, false);
+			Long companyId =
+				(Long)baseModel.getModelAttributes().get("companyId");
+
+			if (companyId != null) {
+				ShardUtil.pushCompanyService(companyId);
+			}
+
+			try {
+				EntityCacheUtil.putResult(
+					baseModel.isEntityCacheEnabled(), entity.getClass(),
+					baseModel.getPrimaryKeyObj(), baseModel, false);
+			}
+			finally {
+				if (companyId != null) {
+					ShardUtil.popCompanyService();
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi @shuyangzhou,

For updates in the persistance layer, when the mehod SessionFlush() (which triggers the mvccVersion listener) is executed the shard stack doesn't contain the proper shard. I have fixed it following the pattern of:
com.liferay.portal.search.lucene.LuceneIndexer.reindex(int)
com.liferay.portal.security.ldap.PortalLDAPImporterImpl.importLDAPUserByScreenName(long, String)

But please, refactor it as you think since I am not an expert in this part.

Please take into account the following information:
https://issues.liferay.com/browse/LPS-46104

Thanks.

PS: This issue has been brought to light after https://github.com/shuyangzhou/liferay-portal/pull/534 so we have to solve them at the same time.@tmoreira2020
