### PR TITLE
Optimize AssetSearchTests 

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/BaseAssetSearchTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/BaseAssetSearchTestCase.java
@@ -23,8 +23,8 @@ import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
-import com.liferay.portal.test.DeleteAfterTestRun;
 import com.liferay.portal.test.Sync;
 import com.liferay.portal.test.listeners.MainServletExecutionTestListener;
 import com.liferay.portal.test.runners.LiferayIntegrationJUnitTestRunner;
@@ -53,8 +53,9 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -66,8 +67,8 @@ import org.junit.runner.RunWith;
 @Sync
 public abstract class BaseAssetSearchTestCase {
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeClass
+	public static void setUpClass() throws Exception {
 		_group = GroupTestUtil.addGroup();
 
 		ServiceContext serviceContext =
@@ -137,6 +138,11 @@ public abstract class BaseAssetSearchTestCase {
 		_assetTagsNames1 =
 			new String[] {"liferay", "architecture", "modularity", "osgi"};
 		_assetTagsNames2 = new String[] {"liferay", "architecture", "services"};
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		GroupLocalServiceUtil.deleteGroup(_group);
 	}
 
 	@Test
@@ -1264,19 +1270,16 @@ public abstract class BaseAssetSearchTestCase {
 		return results.getLength();
 	}
 
-	private long[] _assetCategoryIds1;
-	private long[] _assetCategoryIds2;
-	private String[] _assetTagsNames1;
-	private String[] _assetTagsNames2;
-	private long _fashionCategoryId;
-	private long _foodCategoryId;
-
-	@DeleteAfterTestRun
-	private Group _group;
-
-	private long _healthCategoryId;
-	private long _sportCategoryId;
-	private long _travelCategoryId;
-	private long _vocabularyId;
+	private static long[] _assetCategoryIds1;
+	private static long[] _assetCategoryIds2;
+	private static String[] _assetTagsNames1;
+	private static String[] _assetTagsNames2;
+	private static long _fashionCategoryId;
+	private static long _foodCategoryId;
+	private static Group _group;
+	private static long _healthCategoryId;
+	private static long _sportCategoryId;
+	private static long _travelCategoryId;
+	private static long _vocabularyId;
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/blogs/asset/BlogsEntryAssetSearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/asset/BlogsEntryAssetSearchTest.java
@@ -17,6 +17,7 @@ package com.liferay.portlet.blogs.asset;
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.test.DeleteAfterTestRun;
 import com.liferay.portal.test.Sync;
 import com.liferay.portal.test.SynchronousDestinationExecutionTestListener;
 import com.liferay.portal.test.listeners.MainServletExecutionTestListener;
@@ -25,6 +26,9 @@ import com.liferay.portal.util.test.TestPropsValues;
 import com.liferay.portlet.asset.service.persistence.BaseAssetSearchTestCase;
 import com.liferay.portlet.blogs.model.BlogsEntry;
 import com.liferay.portlet.blogs.util.test.BlogsTestUtil;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -60,8 +64,11 @@ public class BlogsEntryAssetSearchTest extends BaseAssetSearchTestCase {
 			ServiceContext serviceContext)
 		throws Exception {
 
-		return BlogsTestUtil.addEntry(
+		BlogsEntry blogsEntry = BlogsTestUtil.addEntry(
 			TestPropsValues.getUserId(), keywords, true, serviceContext);
+
+		_blogsEntries.add(blogsEntry);
+		return blogsEntry;
 	}
 
 	@Override
@@ -73,5 +80,8 @@ public class BlogsEntryAssetSearchTest extends BaseAssetSearchTestCase {
 	protected String getSearchKeywords() {
 		return "title";
 	}
+
+	@DeleteAfterTestRun
+	private Set<BlogsEntry> _blogsEntries = new HashSet<BlogsEntry>();
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/journal/asset/JournalArticleAssetSearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/asset/JournalArticleAssetSearchTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.ExecutionTestListeners;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.test.DeleteAfterTestRun;
 import com.liferay.portal.test.Sync;
 import com.liferay.portal.test.SynchronousDestinationExecutionTestListener;
 import com.liferay.portal.test.listeners.MainServletExecutionTestListener;
@@ -31,6 +32,8 @@ import com.liferay.portlet.journal.model.JournalArticle;
 import com.liferay.portlet.journal.util.test.JournalTestUtil;
 
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.runner.RunWith;
 
@@ -54,9 +57,12 @@ public class JournalArticleAssetSearchTest extends BaseAssetSearchTestCase {
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
 
-		return JournalTestUtil.addArticle(
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			serviceContext.getScopeGroupId(), keywords, "Content",
 			expirationDate, serviceContext);
+
+		_journalArticles.add(journalArticle);
+		return journalArticle;
 	}
 
 	@Override
@@ -67,9 +73,12 @@ public class JournalArticleAssetSearchTest extends BaseAssetSearchTestCase {
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
 
-		return JournalTestUtil.addArticle(
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			serviceContext.getScopeGroupId(), keywords, "Content",
 			serviceContext);
+
+		_journalArticles.add(journalArticle);
+		return journalArticle;
 	}
 
 	@Override
@@ -92,9 +101,13 @@ public class JournalArticleAssetSearchTest extends BaseAssetSearchTestCase {
 
 		String content = DDMStructureTestUtil.getSampleStructuredContent();
 
-		return JournalTestUtil.addArticleWithXMLContent(
-			serviceContext.getScopeGroupId(), content,
-			_ddmStructure.getStructureKey(), _ddmTemplate.getTemplateKey());
+		JournalArticle journalArticle =
+			JournalTestUtil.addArticleWithXMLContent(
+				serviceContext.getScopeGroupId(), content,
+				_ddmStructure.getStructureKey(), _ddmTemplate.getTemplateKey());
+
+		_journalArticles.add(journalArticle);
+		return journalArticle;
 	}
 
 	@Override
@@ -118,5 +131,9 @@ public class JournalArticleAssetSearchTest extends BaseAssetSearchTestCase {
 
 	protected DDMStructure _ddmStructure;
 	protected DDMTemplate _ddmTemplate;
+
+	@DeleteAfterTestRun
+	private Set<JournalArticle> _journalArticles =
+		new HashSet<JournalArticle>();
 
 }


### PR DESCRIPTION
Regrouped the tests in Base to get rid of redundant object creation. Also added manual cleanup to BlogsEntry and JournalArticle.
