### PR TITLE
LPD-79315

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexSearcherLoggingTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexSearcherLoggingTest.java
@@ -44,9 +44,18 @@ public class ElasticsearchIndexSearcherLoggingTest
 
 			searchCount(createSearchContext(), new MatchAllQuery());
 
-			_assertLogCapture(
-				logCapture, "The search engine processed", LoggerTestUtil.DEBUG,
-				2);
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
+
+			_assertLogEntry(
+				logEntries.get(0), "Stack trace for", LoggerTestUtil.INFO);
+			_assertLogEntry(
+				logEntries.get(1), "Search request string for",
+				LoggerTestUtil.DEBUG);
+			_assertLogEntry(
+				logEntries.get(2), "The search engine processed the request in",
+				LoggerTestUtil.DEBUG);
 		}
 	}
 
@@ -58,8 +67,15 @@ public class ElasticsearchIndexSearcherLoggingTest
 
 			searchCount(createSearchContext(), new MatchAllQuery());
 
-			_assertLogCapture(
-				logCapture, "The search engine processed", LoggerTestUtil.INFO);
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 2, logEntries.size());
+
+			_assertLogEntry(
+				logEntries.get(0), "The search engine processed",
+				LoggerTestUtil.INFO);
+			_assertLogEntry(
+				logEntries.get(1), "Searching took", LoggerTestUtil.INFO);
 		}
 	}
 
@@ -71,49 +87,38 @@ public class ElasticsearchIndexSearcherLoggingTest
 
 			search(createSearchContext());
 
-			_assertLogCapture(
-				logCapture, "The search engine processed", LoggerTestUtil.INFO);
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 2, logEntries.size());
+
+			_assertLogEntry(
+				logEntries.get(0), "The search engine processed",
+				LoggerTestUtil.INFO);
+			_assertLogEntry(
+				logEntries.get(1), "Searching took", LoggerTestUtil.INFO);
 		}
 	}
 
 	@Test
-	public void testSearchSearchRequestExecutorLogsExecutionTime() {
+	public void testSearchSearchRequestExecutorLogs() {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				SearchSearchRequestExecutor.class.getName(),
 				LoggerTestUtil.DEBUG)) {
 
 			search(createSearchContext());
 
-			_assertLogCapture(
-				logCapture, "The search engine processed the request in",
-				LoggerTestUtil.DEBUG, 2);
-		}
-	}
+			List<LogEntry> logEntries = logCapture.getLogEntries();
 
-	@Test
-	public void testSearchSearchRequestExecutorLogsRequestString() {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				SearchSearchRequestExecutor.class.getName(),
-				LoggerTestUtil.DEBUG)) {
+			Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
 
-			search(createSearchContext());
-
-			_assertLogCapture(
-				logCapture, "Search request string for", LoggerTestUtil.DEBUG,
-				1);
-		}
-	}
-
-	@Test
-	public void testSearchSearchRequestExecutorLogsStackTraceInfo() {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				SearchSearchRequestExecutor.class.getName(),
-				LoggerTestUtil.INFO)) {
-
-			search(createSearchContext());
-
-			_assertLogCapture(
-				logCapture, "Stack trace for", LoggerTestUtil.INFO);
+			_assertLogEntry(
+				logEntries.get(0), "Stack trace for", LoggerTestUtil.INFO);
+			_assertLogEntry(
+				logEntries.get(1), "Search request string for",
+				LoggerTestUtil.DEBUG);
+			_assertLogEntry(
+				logEntries.get(2), "The search engine processed the request in",
+				LoggerTestUtil.DEBUG);
 		}
 	}
 
@@ -122,24 +127,10 @@ public class ElasticsearchIndexSearcherLoggingTest
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
 	}
 
-	private void _assertLogCapture(
-		LogCapture logCapture, String expectedMessage, String logLevel) {
-
-		_assertLogCapture(logCapture, expectedMessage, logLevel, 0);
-	}
-
-	private void _assertLogCapture(
-		LogCapture logCapture, String expectedMessage, String logLevel,
-		int index) {
-
-		List<LogEntry> logEntries = logCapture.getLogEntries();
-
-		Assert.assertFalse(logEntries.toString(), logEntries.isEmpty());
-
-		LogEntry logEntry = logEntries.get(index);
+	private void _assertLogEntry(
+		LogEntry logEntry, String expectedMessage, String logLevel) {
 
 		Assert.assertEquals(logLevel, logEntry.getPriority());
-
 		Assert.assertTrue(
 			logEntry.getMessage(
 			).startsWith(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexSearcherLoggingTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexSearcherLoggingTest.java
@@ -6,17 +6,20 @@
 package com.liferay.portal.search.elasticsearch8.internal.logging;
 
 import com.liferay.portal.kernel.search.generic.MatchAllQuery;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.search.elasticsearch8.internal.ElasticsearchIndexSearcher;
 import com.liferay.portal.search.elasticsearch8.internal.indexing.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.search.CountSearchRequestExecutor;
 import com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.search.SearchSearchRequestExecutor;
-import com.liferay.portal.search.test.rule.logging.ExpectedLogMethodTestRule;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
-import com.liferay.portal.search.test.util.logging.ExpectedLog;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.List;
+
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,72 +33,118 @@ public class ElasticsearchIndexSearcherLoggingTest
 
 	@ClassRule
 	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
 
-	@ExpectedLog(
-		expectedClass = CountSearchRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "The search engine processed"
-	)
 	@Test
 	public void testCountSearchRequestExecutorLogsViaIndexer() {
-		searchCount(createSearchContext(), new MatchAllQuery());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				CountSearchRequestExecutor.class.getName(),
+				LoggerTestUtil.DEBUG)) {
+
+			searchCount(createSearchContext(), new MatchAllQuery());
+
+			_assertLogCapture(
+				logCapture, "The search engine processed", LoggerTestUtil.DEBUG,
+				2);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexSearcher.class,
-		expectedLevel = ExpectedLog.Level.INFO,
-		expectedLog = "The search engine processed"
-	)
 	@Test
 	public void testIndexerSearchCountLogs() {
-		searchCount(createSearchContext(), new MatchAllQuery());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexSearcher.class.getName(),
+				LoggerTestUtil.INFO)) {
+
+			searchCount(createSearchContext(), new MatchAllQuery());
+
+			_assertLogCapture(
+				logCapture, "The search engine processed", LoggerTestUtil.INFO);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexSearcher.class,
-		expectedLevel = ExpectedLog.Level.INFO,
-		expectedLog = "The search engine processed"
-	)
 	@Test
 	public void testIndexerSearchLogs() {
-		search(createSearchContext());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexSearcher.class.getName(),
+				LoggerTestUtil.INFO)) {
+
+			search(createSearchContext());
+
+			_assertLogCapture(
+				logCapture, "The search engine processed", LoggerTestUtil.INFO);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = SearchSearchRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "The search engine processed the request in"
-	)
 	@Test
 	public void testSearchSearchRequestExecutorLogsExecutionTime() {
-		search(createSearchContext());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				SearchSearchRequestExecutor.class.getName(),
+				LoggerTestUtil.DEBUG)) {
+
+			search(createSearchContext());
+
+			_assertLogCapture(
+				logCapture, "The search engine processed the request in",
+				LoggerTestUtil.DEBUG, 2);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = SearchSearchRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "Search request string for"
-	)
 	@Test
 	public void testSearchSearchRequestExecutorLogsRequestString() {
-		search(createSearchContext());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				SearchSearchRequestExecutor.class.getName(),
+				LoggerTestUtil.DEBUG)) {
+
+			search(createSearchContext());
+
+			_assertLogCapture(
+				logCapture, "Search request string for", LoggerTestUtil.DEBUG,
+				1);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = SearchSearchRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.INFO, expectedLog = "Stack trace for"
-	)
 	@Test
 	public void testSearchSearchRequestExecutorLogsStackTraceInfo() {
-		search(createSearchContext());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				SearchSearchRequestExecutor.class.getName(),
+				LoggerTestUtil.INFO)) {
+
+			search(createSearchContext());
+
+			_assertLogCapture(
+				logCapture, "Stack trace for", LoggerTestUtil.INFO);
+		}
 	}
 
 	@Override
 	protected IndexingFixture createIndexingFixture() {
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+	private void _assertLogCapture(
+		LogCapture logCapture, String expectedMessage, String logLevel) {
+
+		_assertLogCapture(logCapture, expectedMessage, logLevel, 0);
+	}
+
+	private void _assertLogCapture(
+		LogCapture logCapture, String expectedMessage, String logLevel,
+		int index) {
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertFalse(logEntries.toString(), logEntries.isEmpty());
+
+		LogEntry logEntry = logEntries.get(index);
+
+		Assert.assertEquals(logLevel, logEntry.getPriority());
+
+		Assert.assertTrue(
+			logEntry.getMessage(
+			).startsWith(
+				expectedMessage
+			));
 	}
 
 }


### PR DESCRIPTION
@shuyangzhou  This is not a final PR, but this case should help me define how to handle similar scenarios. Unlike the other changes, here we have multiple log entries. For example:


```
 [{level=INFO, message=Stack trace for [1930456806963985522]: com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.search.SearchSearchRequestExecutor.execute(SearchSearchRequestExecutor.java:60) @@ com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.search.ElasticsearchSearchRequestExecutor.executeSearchRequest(ElasticsearchSearchRequestExecutor.java:91) @@ com.liferay.portal.search.engine.adapter.search.SearchSearchRequest.accept(SearchSearchRequest.java:37) @@ com.liferay.portal.search.engine.adapter.search.SearchSearchRequest.accept(SearchSearchRequest.java:26) @@ com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.ElasticsearchSearchEngineAdapterImpl.execute(ElasticsearchSearchEngineAdapterImpl.java:204) @@ com.liferay.portal.search.elasticsearch8.internal.ElasticsearchIndexSearcher._search(ElasticsearchIndexSearcher.java:594) @@ com.liferay.portal.search.elasticsearch8.internal.ElasticsearchIndexSearcher.search(ElasticsearchIndexSearcher.java:143) @@ com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase.search(BaseIndexingTestCase.java:280) @@ com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase.search(BaseIndexingTestCase.java:275) @@ com.liferay.portal.search.elasticsearch8.internal.logging.ElasticsearchIndexSearcherLoggingTest.testSearchSearchRequestExecutorLogsRequestString(ElasticsearchIndexSearcherLoggingTest.java:99) @@ java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) @@ java.base/java.lang.reflect.Method.invoke(Method.java:580) @@ org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59) @@ org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) @@ org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56) @@ org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) @@ org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26) @@ org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27) @@ com.liferay.portal.kernel.test.rule.AbstractTestRule$2.evaluate(AbstractTestRule.java:90) @@ com.liferay.portal.kernel.test.rule.AbstractTestRule$2.evaluate(AbstractTestRule.java:90) @@ org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61) @@ org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306) @@ org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100) @@ org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366) @@ org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103) @@ org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63) @@ org.junit.runners.ParentRunner$4.run(ParentRunner.java:331) @@ org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79) @@ org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329) @@ org.junit.runners.ParentRunner.access$100(ParentRunner.java:66) @@ org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293) @@ org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26) @@ org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27) @@ com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50) @@ com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50) @@ org.junit.rules.RunRules.evaluate(RunRules.java:20) @@ org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306) @@ org.junit.runners.ParentRunner.run(ParentRunner.java:413) @@ org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:112) @@ org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58) @@ org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40) @@ org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:60) @@ org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52) @@ java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) @@ java.base/java.lang.reflect.Method.invoke(Method.java:580) @@ org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36) @@ org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24) @@ org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)}, {level=DEBUG, message=Search request string for [1930456806963985522]: {"_source":false,"explain":false,"fields":[{"field":"*"}],"from":0,"query":{"bool":{"must":[{"term":{"entryClassName":{"value":"elasticsearchindexsearcherloggingtest.testsearchsearchrequestexecutorlogsrequeststring"}}},{"term":{"companyId":{"value":"1930456806963985522"}}}]}},"size":20,"sort":[],"track_scores":false,"track_total_hits":2147483647}}, {level=DEBUG, message=The search engine processed the request in 3 ms}]
```


An AI suggested merging all the logs using a StringBuilder and doing an assert with contains, like this:



```
	private void _assertLogCapture(
		LogCapture logCapture, String expectedMessage) {

		List<LogEntry> logEntries = logCapture.getLogEntries();

		Assert.assertFalse(logEntries.toString(), logEntries.isEmpty());

		StringBuilder sb = new StringBuilder();

		for (LogEntry logEntry : logEntries) {
			sb.append(logEntry.getMessage());
		}

		String messages = sb.toString();

		Assert.assertTrue(messages, messages.contains(expectedMessage));
	}
```

But initially, I didn't think this was strict enough. Instead, I thought about fetching the log from its specific index and using .startsWith() (or similar) for a stronger assertion. Would this be considered a valid approach?