### PR TITLE
LPD-83973 Cannot download a document from the Sharepoint repository

### DIFF
--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepository.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepository.java
@@ -33,6 +33,9 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -59,11 +62,8 @@ import com.mashape.unirest.request.HttpRequestWithBody;
 import java.io.IOException;
 import java.io.InputStream;
 
-import java.net.MalformedURLException;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 /**
  * @author Adolfo Pérez
@@ -713,17 +713,24 @@ public class SharepointExtRepository implements ExtRepository {
 					sharepointRepositoryTokenBroker.requestAccessTokenSilently(
 						token);
 
-			_tokenStore.save(
-				_sharepointRepositoryConfiguration.name(),
-				PrincipalThreadLocal.getUserId(),
-				sharepointRepositoryAuthenticationResult.getToken());
+			TransactionInvokerUtil.invoke(
+				_transactionConfig,
+				() -> {
+					_tokenStore.save(
+						_sharepointRepositoryConfiguration.name(),
+						PrincipalThreadLocal.getUserId(),
+						sharepointRepositoryAuthenticationResult.getToken());
+
+					return null;
+				});
 
 			return sharepointRepositoryAuthenticationResult.getAccessToken();
 		}
-		catch (ExecutionException | InterruptedException | MalformedURLException
-					exception) {
-
-			throw new PortalException(exception);
+		catch (PortalException portalException) {
+			throw portalException;
+		}
+		catch (Throwable throwable) {
+			throw new PortalException(throwable);
 		}
 	}
 
@@ -926,6 +933,10 @@ public class SharepointExtRepository implements ExtRepository {
 
 	private static final String _RESULTS_SOURCE_ID =
 		"8413cd39-2156-4e00-b54d-11efd9abdb89";
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
 
 	private String _libraryPath;
 	private ExtRepositoryFolder _rootFolder;

--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepository.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepository.java
@@ -713,16 +713,30 @@ public class SharepointExtRepository implements ExtRepository {
 					sharepointRepositoryTokenBroker.requestAccessTokenSilently(
 						token);
 
-			TransactionInvokerUtil.invoke(
-				_transactionConfig,
-				() -> {
-					_tokenStore.save(
-						_sharepointRepositoryConfiguration.name(),
-						PrincipalThreadLocal.getUserId(),
-						sharepointRepositoryAuthenticationResult.getToken());
+			Token newToken =
+				sharepointRepositoryAuthenticationResult.getToken();
 
-					return null;
-				});
+			if (newToken != null) {
+				Token storedToken = _tokenStore.get(
+					_sharepointRepositoryConfiguration.name(),
+					PrincipalThreadLocal.getUserId());
+
+				if ((storedToken == null) ||
+					!StringUtil.equals(
+						newToken.getAccessToken(),
+						storedToken.getAccessToken())) {
+
+					TransactionInvokerUtil.invoke(
+						_transactionConfig,
+						() -> {
+							_tokenStore.save(
+								_sharepointRepositoryConfiguration.name(),
+								PrincipalThreadLocal.getUserId(), newToken);
+
+							return null;
+						});
+				}
+			}
 
 			return sharepointRepositoryAuthenticationResult.getAccessToken();
 		}

--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/test/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepositoryTest.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/test/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepositoryTest.java
@@ -1,0 +1,258 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharepoint.rest.repository.internal.document.library.repository.external;
+
+import com.liferay.document.library.repository.authorization.oauth2.Token;
+import com.liferay.document.library.repository.authorization.oauth2.TokenStore;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvoker;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.sharepoint.rest.repository.internal.configuration.SharepointRepositoryConfiguration;
+import com.liferay.sharepoint.rest.repository.internal.document.library.repository.authorization.oauth2.SharepointRepositoryAuthenticationResult;
+import com.liferay.sharepoint.rest.repository.internal.document.library.repository.authorization.oauth2.SharepointRepositoryToken;
+import com.liferay.sharepoint.rest.repository.internal.document.library.repository.authorization.oauth2.SharepointRepositoryTokenBroker;
+import com.liferay.sharepoint.rest.repository.internal.document.library.repository.authorization.oauth2.util.SharepointRepositoryTokenBrokerFactoryUtil;
+
+import java.util.concurrent.Callable;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Manuel Rives
+ */
+public class SharepointExtRepositoryTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		TransactionInvokerUtil transactionInvokerUtil =
+			new TransactionInvokerUtil();
+
+		transactionInvokerUtil.setTransactionInvoker(
+			new TransactionInvoker() {
+
+				@Override
+				public <T> T invoke(
+						TransactionConfig transactionConfig,
+						Callable<T> callable)
+					throws Throwable {
+
+					return callable.call();
+				}
+
+			});
+	}
+
+	@Before
+	public void setUp() {
+		PrincipalThreadLocal.setName(_USER_ID);
+
+		_sharepointRepositoryTokenBrokerFactoryUtilMockedStatic =
+			Mockito.mockStatic(
+				SharepointRepositoryTokenBrokerFactoryUtil.class);
+	}
+
+	@After
+	public void tearDown() {
+		_sharepointRepositoryTokenBrokerFactoryUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testGetAccessTokenDoesNotSaveWhenTokenUnchanged()
+		throws Exception {
+
+		String accessToken = RandomTestUtil.randomString();
+
+		Token brokerToken = SharepointRepositoryToken.newInstance(accessToken);
+		Token cachedToken = SharepointRepositoryToken.newInstance(accessToken);
+
+		TokenStore tokenStore = Mockito.mock(TokenStore.class);
+
+		Mockito.when(
+			tokenStore.get(_CONFIGURATION_NAME, _USER_ID)
+		).thenReturn(
+			cachedToken
+		);
+
+		SharepointRepositoryConfiguration sharepointRepositoryConfiguration =
+			_mockSharepointRepositoryConfiguration();
+
+		_mockBroker(
+			brokerToken, cachedToken, sharepointRepositoryConfiguration);
+
+		SharepointExtRepository sharepointExtRepository =
+			new SharepointExtRepository(
+				tokenStore, sharepointRepositoryConfiguration);
+
+		String result = ReflectionTestUtil.invoke(
+			sharepointExtRepository, "_getAccessToken", new Class<?>[0]);
+
+		Assert.assertEquals(_RETURNED_ACCESS_TOKEN, result);
+
+		Mockito.verify(
+			tokenStore, Mockito.never()
+		).save(
+			Mockito.anyString(), Mockito.anyLong(), Mockito.any(Token.class)
+		);
+	}
+
+	@Test
+	public void testGetAccessTokenSavesWhenStoredTokenIsMissing()
+		throws Exception {
+
+		Token brokerToken = SharepointRepositoryToken.newInstance(
+			RandomTestUtil.randomString());
+		Token cachedToken = SharepointRepositoryToken.newInstance(
+			RandomTestUtil.randomString());
+
+		TokenStore tokenStore = Mockito.mock(TokenStore.class);
+
+		Mockito.when(
+			tokenStore.get(_CONFIGURATION_NAME, _USER_ID)
+		).thenReturn(
+			cachedToken, (Token)null
+		);
+
+		SharepointRepositoryConfiguration sharepointRepositoryConfiguration =
+			_mockSharepointRepositoryConfiguration();
+
+		_mockBroker(
+			brokerToken, cachedToken, sharepointRepositoryConfiguration);
+
+		SharepointExtRepository sharepointExtRepository =
+			new SharepointExtRepository(
+				tokenStore, sharepointRepositoryConfiguration);
+
+		ReflectionTestUtil.invoke(
+			sharepointExtRepository, "_getAccessToken", new Class<?>[0]);
+
+		Mockito.verify(
+			tokenStore
+		).save(
+			_CONFIGURATION_NAME, _USER_ID, brokerToken
+		);
+	}
+
+	@Test
+	public void testGetAccessTokenSavesWhenTokenChanged() throws Exception {
+		Token brokerToken = SharepointRepositoryToken.newInstance(
+			RandomTestUtil.randomString());
+		Token cachedToken = SharepointRepositoryToken.newInstance(
+			RandomTestUtil.randomString());
+
+		TokenStore tokenStore = Mockito.mock(TokenStore.class);
+
+		Mockito.when(
+			tokenStore.get(_CONFIGURATION_NAME, _USER_ID)
+		).thenReturn(
+			cachedToken
+		);
+
+		SharepointRepositoryConfiguration sharepointRepositoryConfiguration =
+			_mockSharepointRepositoryConfiguration();
+
+		_mockBroker(
+			brokerToken, cachedToken, sharepointRepositoryConfiguration);
+
+		SharepointExtRepository sharepointExtRepository =
+			new SharepointExtRepository(
+				tokenStore, sharepointRepositoryConfiguration);
+
+		String result = ReflectionTestUtil.invoke(
+			sharepointExtRepository, "_getAccessToken", new Class<?>[0]);
+
+		Assert.assertEquals(_RETURNED_ACCESS_TOKEN, result);
+
+		Mockito.verify(
+			tokenStore
+		).save(
+			_CONFIGURATION_NAME, _USER_ID, brokerToken
+		);
+	}
+
+	private void _mockBroker(
+			Token brokerToken, Token cachedToken,
+			SharepointRepositoryConfiguration sharepointRepositoryConfiguration)
+		throws Exception {
+
+		SharepointRepositoryAuthenticationResult
+			sharepointRepositoryAuthenticationResult = Mockito.mock(
+				SharepointRepositoryAuthenticationResult.class);
+
+		Mockito.when(
+			sharepointRepositoryAuthenticationResult.getAccessToken()
+		).thenReturn(
+			_RETURNED_ACCESS_TOKEN
+		);
+
+		Mockito.when(
+			sharepointRepositoryAuthenticationResult.getToken()
+		).thenReturn(
+			brokerToken
+		);
+
+		SharepointRepositoryTokenBroker sharepointRepositoryTokenBroker =
+			Mockito.mock(SharepointRepositoryTokenBroker.class);
+
+		Mockito.when(
+			sharepointRepositoryTokenBroker.requestAccessTokenSilently(
+				cachedToken)
+		).thenReturn(
+			sharepointRepositoryAuthenticationResult
+		);
+
+		_sharepointRepositoryTokenBrokerFactoryUtilMockedStatic.when(
+			() -> SharepointRepositoryTokenBrokerFactoryUtil.create(
+				sharepointRepositoryConfiguration)
+		).thenReturn(
+			sharepointRepositoryTokenBroker
+		);
+	}
+
+	private SharepointRepositoryConfiguration
+		_mockSharepointRepositoryConfiguration() {
+
+		SharepointRepositoryConfiguration sharepointRepositoryConfiguration =
+			Mockito.mock(SharepointRepositoryConfiguration.class);
+
+		Mockito.when(
+			sharepointRepositoryConfiguration.name()
+		).thenReturn(
+			_CONFIGURATION_NAME
+		);
+
+		return sharepointRepositoryConfiguration;
+	}
+
+	private static final String _CONFIGURATION_NAME =
+		RandomTestUtil.randomString();
+
+	private static final String _RETURNED_ACCESS_TOKEN =
+		RandomTestUtil.randomString();
+
+	private static final long _USER_ID = RandomTestUtil.randomLong();
+
+	private MockedStatic<SharepointRepositoryTokenBrokerFactoryUtil>
+		_sharepointRepositoryTokenBrokerFactoryUtilMockedStatic;
+
+}


### PR DESCRIPTION
Sending this pull per Brian request https://github.com/brianchandotcom/liferay-portal/pull/173717

### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-83973 Cannot download a document from the Sharepoint repository

If the action is launched from a read only transaction like Download the portal fails storing the new token.

### How am I fixing it?

1. Moving the store of the token to a new transaction.
2. Storing only the token when it has been modified.

### How can you verify that it works?
Running included test.