### PR TITLE
LPD-79315-3 -  Remove ExpectedLog usage

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
@@ -35,6 +35,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 /**
  * @author Bryan Engler
@@ -49,20 +50,11 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 	@Test
 	public void testAddDocument() {
-		String expectedMessage =
-			"failed to parse field [expirationDate] of type [date]";
-
-		ElasticsearchException elasticsearchException = Assert.assertThrows(
-			ElasticsearchException.class,
+		_assertElasticsearchException(
+			"failed to parse field [expirationDate] of type [date]",
 			() -> addDocument(
 				DocumentCreationHelpers.singleKeyword(
 					Field.EXPIRATION_DATE, "text")));
-
-		String message = elasticsearchException.getMessage();
-
-		Assert.assertTrue(
-			message + " does not contain " + expectedMessage,
-			message.contains(expectedMessage));
 	}
 
 	@Test
@@ -85,13 +77,10 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			RuntimeException runtimeException = Assert.assertThrows(
-				RuntimeException.class,
+			_assertRuntimeException(
+				"Bulk add failed",
 				() -> indexWriter.addDocuments(
 					createSearchContext(), documents));
-
-			Assert.assertEquals(
-				"Bulk add failed", runtimeException.getMessage());
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -103,23 +92,15 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 	@Test
 	public void testCommit() {
-		String expectedMessage = "[index_not_found_exception] no such index";
-
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(1);
 
 		IndexWriter indexWriter = getIndexWriter();
 
-		ElasticsearchException elasticsearchException = Assert.assertThrows(
-			ElasticsearchException.class,
+		_assertElasticsearchException(
+			"[index_not_found_exception] no such index",
 			() -> indexWriter.commit(searchContext));
-
-		String message = elasticsearchException.getMessage();
-
-		Assert.assertTrue(
-			message + " does not contain " + expectedMessage,
-			message.contains(expectedMessage));
 	}
 
 	@Test
@@ -173,12 +154,9 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			RuntimeException runtimeException = Assert.assertThrows(
-				RuntimeException.class,
+			_assertRuntimeException(
+				"Bulk delete failed",
 				() -> indexWriter.deleteDocuments(searchContext, uids));
-
-			Assert.assertEquals(
-				"Bulk delete failed", runtimeException.getMessage());
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -190,23 +168,15 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 	@Test
 	public void testDeleteEntityDocuments() {
-		String expectedMessage = "[index_not_found_exception] no such index";
-
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(1);
 
 		IndexWriter indexWriter = getIndexWriter();
 
-		ElasticsearchException elasticsearchException = Assert.assertThrows(
-			ElasticsearchException.class,
+		_assertElasticsearchException(
+			"[index_not_found_exception] no such index",
 			() -> indexWriter.deleteEntityDocuments(searchContext, "test"));
-
-		String message = elasticsearchException.getMessage();
-
-		Assert.assertTrue(
-			message + " does not contain " + expectedMessage,
-			message.contains(expectedMessage));
 	}
 
 	@Test
@@ -252,12 +222,10 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			RuntimeException runtimeException = Assert.assertThrows(
-				RuntimeException.class,
+			_assertRuntimeException(
+				"Update failed",
 				() -> indexWriter.updateDocument(
 					createSearchContext(), document));
-
-			Assert.assertEquals("Update failed", runtimeException.getMessage());
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -288,13 +256,10 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			RuntimeException runtimeException = Assert.assertThrows(
-				RuntimeException.class,
+			_assertRuntimeException(
+				"Bulk update failed",
 				() -> indexWriter.updateDocuments(
 					createSearchContext(), documents));
-
-			Assert.assertEquals(
-				"Bulk update failed", runtimeException.getMessage());
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -309,6 +274,19 @@ public class ElasticsearchIndexWriterExceptionsTest
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
 	}
 
+	private void _assertElasticsearchException(
+		String expectedMessage, ThrowingRunnable runnable) {
+
+		ElasticsearchException elasticsearchException = Assert.assertThrows(
+			ElasticsearchException.class, runnable);
+
+		String message = elasticsearchException.getMessage();
+
+		Assert.assertTrue(
+			message + " does not contain " + expectedMessage,
+			message.contains(expectedMessage));
+	}
+
 	private void _assertLogCapture(
 		Consumer<String> consumer, LogCapture logCapture, String logLevel) {
 
@@ -320,6 +298,15 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 		Assert.assertEquals(logLevel, logEntry.getPriority());
 		consumer.accept(logEntry.getMessage());
+	}
+
+	private void _assertRuntimeException(
+		String expectedMessage, ThrowingRunnable runnable) {
+
+		RuntimeException runtimeException = Assert.assertThrows(
+			RuntimeException.class, runnable);
+
+		Assert.assertEquals(expectedMessage, runtimeException.getMessage());
 	}
 
 	private static final String _UID = "1";

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
@@ -49,17 +49,20 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 	@Test
 	public void testAddDocument() {
+		String expectedMessage =
+			"failed to parse field [expirationDate] of type [date]";
+
 		ElasticsearchException elasticsearchException = Assert.assertThrows(
 			ElasticsearchException.class,
 			() -> addDocument(
 				DocumentCreationHelpers.singleKeyword(
 					Field.EXPIRATION_DATE, "text")));
 
+		String message = elasticsearchException.getMessage();
+
 		Assert.assertTrue(
-			elasticsearchException.getMessage(
-			).contains(
-				"failed to parse field [expirationDate] of type [date]"
-			));
+			message + " does not contain " + expectedMessage,
+			message.contains(expectedMessage));
 	}
 
 	@Test
@@ -67,6 +70,10 @@ public class ElasticsearchIndexWriterExceptionsTest
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
+
+			String expectedMessage =
+				"failed to parse field [expirationDate] of type [date] in " +
+					"document with id";
 
 			List<Document> documents = new ArrayList<>();
 
@@ -88,15 +95,16 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains(
-						"failed to parse field [expirationDate] of type " +
-							"[date] in document with id")),
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
 	@Test
 	public void testCommit() {
+		String expectedMessage = "[index_not_found_exception] no such index";
+
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(1);
@@ -107,11 +115,11 @@ public class ElasticsearchIndexWriterExceptionsTest
 			ElasticsearchException.class,
 			() -> indexWriter.commit(searchContext));
 
+		String message = elasticsearchException.getMessage();
+
 		Assert.assertTrue(
-			elasticsearchException.getMessage(
-			).contains(
-				"[index_not_found_exception] no such index"
-			));
+			message + " does not contain " + expectedMessage,
+			message.contains(expectedMessage));
 	}
 
 	@Test
@@ -156,6 +164,9 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			String uid = "1";
 
+			String expectedMessage = StringBundler.concat(
+				"no such index [", uid, "]");
+
 			SearchContext searchContext = new SearchContext();
 
 			searchContext.setCompanyId(1);
@@ -175,14 +186,16 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains(
-						StringBundler.concat("no such index [", uid, "]"))),
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
 	@Test
 	public void testDeleteEntityDocuments() {
+		String expectedMessage = "[index_not_found_exception] no such index";
+
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(1);
@@ -193,11 +206,11 @@ public class ElasticsearchIndexWriterExceptionsTest
 			ElasticsearchException.class,
 			() -> indexWriter.deleteEntityDocuments(searchContext, "test"));
 
+		String message = elasticsearchException.getMessage();
+
 		Assert.assertTrue(
-			elasticsearchException.getMessage(
-			).contains(
-				"[index_not_found_exception] no such index"
-			));
+			message + " does not contain " + expectedMessage,
+			message.contains(expectedMessage));
 	}
 
 	@Test
@@ -232,6 +245,10 @@ public class ElasticsearchIndexWriterExceptionsTest
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
+			String expectedMessage =
+				"failed to parse field [expirationDate] of type [date] in " +
+					"document with id";
+
 			Document document = new DocumentImpl();
 
 			document.addKeyword(Field.EXPIRATION_DATE, "text");
@@ -248,9 +265,8 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains(
-						"failed to parse field [expirationDate] of type " +
-							"[date] in document with id")),
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
@@ -260,6 +276,10 @@ public class ElasticsearchIndexWriterExceptionsTest
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
+
+			String expectedMessage =
+				"failed to parse field [expirationDate] of type [date] in " +
+					"document with id";
 
 			List<Document> documents = new ArrayList<>();
 
@@ -282,9 +302,8 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains(
-						"failed to parse field [expirationDate] of type " +
-							"[date] in document with id")),
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.search.elasticsearch8.internal.ElasticsearchIndexWriter;
 import com.liferay.portal.search.elasticsearch8.internal.indexing.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.document.BulkDocumentRequestExecutor;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
@@ -61,22 +62,27 @@ public class ElasticsearchIndexWriterExceptionsTest
 		expectedException.expect(RuntimeException.class);
 		expectedException.expectMessage("Bulk add failed");
 
-		List<Document> documents = new ArrayList<>();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		Document document = new DocumentImpl();
+			List<Document> documents = new ArrayList<>();
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
+			Document document = new DocumentImpl();
 
-		documents.add(document);
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
 
-		IndexWriter indexWriter = getIndexWriter();
+			documents.add(document);
 
-		try {
-			indexWriter.addDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.addDocuments(createSearchContext(), documents);
+			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
 			}
 		}
 	}
@@ -135,22 +141,27 @@ public class ElasticsearchIndexWriterExceptionsTest
 		expectedException.expect(RuntimeException.class);
 		expectedException.expectMessage("Bulk delete failed");
 
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(1);
+			SearchContext searchContext = new SearchContext();
 
-		List<String> uids = new ArrayList<>();
+			searchContext.setCompanyId(1);
 
-		uids.add("1");
+			List<String> uids = new ArrayList<>();
 
-		IndexWriter indexWriter = getIndexWriter();
+			uids.add("1");
 
-		try {
-			indexWriter.deleteDocuments(searchContext, uids);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.deleteDocuments(searchContext, uids);
+			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
 			}
 		}
 	}
@@ -208,19 +219,24 @@ public class ElasticsearchIndexWriterExceptionsTest
 		expectedException.expect(RuntimeException.class);
 		expectedException.expectMessage("Update failed");
 
-		Document document = new DocumentImpl();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			Document document = new DocumentImpl();
 
-		IndexWriter indexWriter = getIndexWriter();
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, "1");
 
-		try {
-			indexWriter.updateDocument(createSearchContext(), document);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.updateDocument(createSearchContext(), document);
+			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
 			}
 		}
 	}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
@@ -183,7 +183,7 @@ public class ElasticsearchIndexWriterExceptionsTest
 	public void testPartiallyUpdateDocument() throws SearchException {
 		Document document = new DocumentImpl();
 
-		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.UID, _UID);
 
 		IndexWriter indexWriter = getIndexWriter();
 
@@ -196,7 +196,7 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 		List<Document> documents = new ArrayList<>();
 
-		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.UID, _UID);
 
 		documents.add(document);
 
@@ -218,7 +218,7 @@ public class ElasticsearchIndexWriterExceptionsTest
 			Document document = new DocumentImpl();
 
 			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -250,7 +250,7 @@ public class ElasticsearchIndexWriterExceptionsTest
 			Document document = new DocumentImpl();
 
 			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.UID, _UID);
 
 			documents.add(document);
 

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
@@ -128,8 +128,6 @@ public class ElasticsearchIndexWriterExceptionsTest
 				ElasticsearchIndexWriter.class.getName(),
 				LoggerTestUtil.INFO)) {
 
-			String uid = "1";
-
 			SearchContext searchContext = new SearchContext();
 
 			searchContext.setCompanyId(1);
@@ -137,7 +135,7 @@ public class ElasticsearchIndexWriterExceptionsTest
 			IndexWriter indexWriter = getIndexWriter();
 
 			try {
-				indexWriter.deleteDocument(searchContext, uid);
+				indexWriter.deleteDocument(searchContext, _UID);
 			}
 			catch (SearchException searchException) {
 				if (_log.isDebugEnabled()) {
@@ -150,7 +148,7 @@ public class ElasticsearchIndexWriterExceptionsTest
 					StringBundler.concat(
 						ElasticsearchException.class.getName(),
 						": [es/delete] failed: [index_not_found_exception] no ",
-						"such index [", uid, "]"),
+						"such index [", _UID, "]"),
 					message),
 				logCapture, LoggerTestUtil.INFO);
 		}
@@ -162,10 +160,8 @@ public class ElasticsearchIndexWriterExceptionsTest
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
-			String uid = "1";
-
 			String expectedMessage = StringBundler.concat(
-				"no such index [", uid, "]");
+				"no such index [", _UID, "]");
 
 			SearchContext searchContext = new SearchContext();
 
@@ -173,7 +169,7 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			List<String> uids = new ArrayList<>();
 
-			uids.add(uid);
+			uids.add(_UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -325,6 +321,8 @@ public class ElasticsearchIndexWriterExceptionsTest
 		Assert.assertEquals(logLevel, logEntry.getPriority());
 		consumer.accept(logEntry.getMessage());
 	}
+
+	private static final String _UID = "1";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ElasticsearchIndexWriterExceptionsTest.class);

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
@@ -15,19 +15,20 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.search.elasticsearch8.internal.ElasticsearchIndexWriter;
 import com.liferay.portal.search.elasticsearch8.internal.indexing.LiferayElasticsearchIndexingFixtureFactory;
-import com.liferay.portal.search.test.rule.logging.ExpectedLogMethodTestRule;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
-import com.liferay.portal.search.test.util.logging.ExpectedLog;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,9 +42,8 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 	@ClassRule
 	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
 
 	@Test
 	public void testAddDocument() {
@@ -103,25 +103,30 @@ public class ElasticsearchIndexWriterExceptionsTest
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.INFO, expectedLog = "no such index"
-	)
 	@Test
 	public void testDeleteDocument() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexWriter.class.getName(),
+				LoggerTestUtil.INFO)) {
 
-		searchContext.setCompanyId(1);
+			String uid = "1";
 
-		IndexWriter indexWriter = getIndexWriter();
+			SearchContext searchContext = new SearchContext();
 
-		try {
-			indexWriter.deleteDocument(searchContext, "1");
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			searchContext.setCompanyId(1);
+
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.deleteDocument(searchContext, uid);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(logCapture, uid);
 		}
 	}
 
@@ -252,6 +257,24 @@ public class ElasticsearchIndexWriterExceptionsTest
 	@Override
 	protected IndexingFixture createIndexingFixture() {
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+	private void _assertLogCapture(LogCapture logCapture, String uid) {
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+		LogEntry logEntry = logEntries.get(0);
+
+		Assert.assertEquals(LoggerTestUtil.INFO, logEntry.getPriority());
+
+		Throwable throwable = logEntry.getThrowable();
+
+		Assert.assertEquals(
+			"[es/delete] failed: [index_not_found_exception] no such index [" +
+				uid + "]",
+			throwable.getMessage());
+		Assert.assertSame(ElasticsearchException.class, throwable.getClass());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.search.elasticsearch8.internal.logging;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
@@ -28,12 +29,12 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * @author Bryan Engler
@@ -48,20 +49,21 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 	@Test
 	public void testAddDocument() {
-		expectedException.expect(ElasticsearchException.class);
-		expectedException.expectMessage(
-			"failed to parse field [expirationDate] of type [date]");
+		ElasticsearchException elasticsearchException = Assert.assertThrows(
+			ElasticsearchException.class,
+			() -> addDocument(
+				DocumentCreationHelpers.singleKeyword(
+					Field.EXPIRATION_DATE, "text")));
 
-		addDocument(
-			DocumentCreationHelpers.singleKeyword(
-				Field.EXPIRATION_DATE, "text"));
+		Assert.assertTrue(
+			elasticsearchException.getMessage(
+			).contains(
+				"failed to parse field [expirationDate] of type [date]"
+			));
 	}
 
 	@Test
 	public void testAddDocuments() {
-		expectedException.expect(RuntimeException.class);
-		expectedException.expectMessage("Bulk add failed");
-
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
@@ -76,37 +78,40 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.addDocuments(createSearchContext(), documents);
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			RuntimeException runtimeException = Assert.assertThrows(
+				RuntimeException.class,
+				() -> indexWriter.addDocuments(
+					createSearchContext(), documents));
+
+			Assert.assertEquals(
+				"Bulk add failed", runtimeException.getMessage());
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains(
+						"failed to parse field [expirationDate] of type " +
+							"[date] in document with id")),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
 	@Test
 	public void testCommit() {
-		expectedException.expect(ElasticsearchException.class);
-		expectedException.expectMessage(
-			"[index_not_found_exception] no such index");
-
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(1);
 
 		IndexWriter indexWriter = getIndexWriter();
 
-		try {
-			indexWriter.commit(searchContext);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
-			}
-		}
+		ElasticsearchException elasticsearchException = Assert.assertThrows(
+			ElasticsearchException.class,
+			() -> indexWriter.commit(searchContext));
+
+		Assert.assertTrue(
+			elasticsearchException.getMessage(
+			).contains(
+				"[index_not_found_exception] no such index"
+			));
 	}
 
 	@Test
@@ -132,18 +137,24 @@ public class ElasticsearchIndexWriterExceptionsTest
 				}
 			}
 
-			_assertLogCapture(logCapture, uid);
+			_assertLogCapture(
+				message -> Assert.assertEquals(
+					StringBundler.concat(
+						ElasticsearchException.class.getName(),
+						": [es/delete] failed: [index_not_found_exception] no ",
+						"such index [", uid, "]"),
+					message),
+				logCapture, LoggerTestUtil.INFO);
 		}
 	}
 
 	@Test
 	public void testDeleteDocuments() {
-		expectedException.expect(RuntimeException.class);
-		expectedException.expectMessage("Bulk delete failed");
-
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
+
+			String uid = "1";
 
 			SearchContext searchContext = new SearchContext();
 
@@ -151,41 +162,42 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			List<String> uids = new ArrayList<>();
 
-			uids.add("1");
+			uids.add(uid);
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.deleteDocuments(searchContext, uids);
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			RuntimeException runtimeException = Assert.assertThrows(
+				RuntimeException.class,
+				() -> indexWriter.deleteDocuments(searchContext, uids));
+
+			Assert.assertEquals(
+				"Bulk delete failed", runtimeException.getMessage());
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains(
+						StringBundler.concat("no such index [", uid, "]"))),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
 	@Test
 	public void testDeleteEntityDocuments() {
-		expectedException.expect(ElasticsearchException.class);
-		expectedException.expectMessage(
-			"[index_not_found_exception] no such index");
-
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(1);
 
 		IndexWriter indexWriter = getIndexWriter();
 
-		try {
-			indexWriter.deleteEntityDocuments(searchContext, "test");
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
-			}
-		}
+		ElasticsearchException elasticsearchException = Assert.assertThrows(
+			ElasticsearchException.class,
+			() -> indexWriter.deleteEntityDocuments(searchContext, "test"));
+
+		Assert.assertTrue(
+			elasticsearchException.getMessage(
+			).contains(
+				"[index_not_found_exception] no such index"
+			));
 	}
 
 	@Test
@@ -216,9 +228,6 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 	@Test
 	public void testUpdateDocument() {
-		expectedException.expect(RuntimeException.class);
-		expectedException.expectMessage("Update failed");
-
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
@@ -230,67 +239,72 @@ public class ElasticsearchIndexWriterExceptionsTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.updateDocument(createSearchContext(), document);
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			RuntimeException runtimeException = Assert.assertThrows(
+				RuntimeException.class,
+				() -> indexWriter.updateDocument(
+					createSearchContext(), document));
+
+			Assert.assertEquals("Update failed", runtimeException.getMessage());
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains(
+						"failed to parse field [expirationDate] of type " +
+							"[date] in document with id")),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
 	@Test
 	public void testUpdateDocuments() {
-		expectedException.expect(RuntimeException.class);
-		expectedException.expectMessage("Bulk update failed");
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		List<Document> documents = new ArrayList<>();
+			List<Document> documents = new ArrayList<>();
 
-		Document document = new DocumentImpl();
+			Document document = new DocumentImpl();
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, "1");
 
-		documents.add(document);
+			documents.add(document);
 
-		IndexWriter indexWriter = getIndexWriter();
+			IndexWriter indexWriter = getIndexWriter();
 
-		try {
-			indexWriter.updateDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
-			}
+			RuntimeException runtimeException = Assert.assertThrows(
+				RuntimeException.class,
+				() -> indexWriter.updateDocuments(
+					createSearchContext(), documents));
+
+			Assert.assertEquals(
+				"Bulk update failed", runtimeException.getMessage());
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains(
+						"failed to parse field [expirationDate] of type " +
+							"[date] in document with id")),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	@Override
 	protected IndexingFixture createIndexingFixture() {
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
 	}
 
-	private void _assertLogCapture(LogCapture logCapture, String uid) {
+	private void _assertLogCapture(
+		Consumer<String> consumer, LogCapture logCapture, String logLevel) {
+
 		List<LogEntry> logEntries = logCapture.getLogEntries();
 
 		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
 
 		LogEntry logEntry = logEntries.get(0);
 
-		Assert.assertEquals(LoggerTestUtil.INFO, logEntry.getPriority());
-
-		Throwable throwable = logEntry.getThrowable();
-
-		Assert.assertEquals(
-			"[es/delete] failed: [index_not_found_exception] no such index [" +
-				uid + "]",
-			throwable.getMessage());
-		Assert.assertSame(ElasticsearchException.class, throwable.getClass());
+		Assert.assertEquals(logLevel, logEntry.getPriority());
+		consumer.accept(logEntry.getMessage());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.elasticsearch8.internal.logging;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
@@ -13,23 +14,25 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.search.elasticsearch8.internal.ElasticsearchIndexWriter;
 import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch8.internal.indexing.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.document.BulkDocumentRequestExecutor;
-import com.liferay.portal.search.test.rule.logging.ExpectedLogMethodTestRule;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
-import com.liferay.portal.search.test.util.logging.ExpectedLog;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,95 +45,120 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 	@ClassRule
 	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "failed to parse field [expirationDate] of type [date]"
-	)
 	@Test
 	public void testAddDocument() throws Exception {
-		addDocument(
-			DocumentCreationHelpers.singleKeyword(
-				Field.EXPIRATION_DATE, "text"));
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexWriter.class.getName(),
+				LoggerTestUtil.ERROR)) {
+
+			addDocument(
+				DocumentCreationHelpers.singleKeyword(
+					Field.EXPIRATION_DATE, "text"));
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains(
+						"failed to parse field [expirationDate] of type " +
+							"[date] in document with id")),
+				logCapture, LoggerTestUtil.ERROR);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Bulk add failed"
-	)
 	@Test
 	public void testAddDocuments() {
-		List<Document> documents = new ArrayList<>();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexWriter.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		Document document = new DocumentImpl();
+			List<Document> documents = new ArrayList<>();
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
+			Document document = new DocumentImpl();
 
-		documents.add(document);
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
 
-		IndexWriter indexWriter = getIndexWriter();
+			documents.add(document);
 
-		try {
-			indexWriter.addDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.addDocuments(createSearchContext(), documents);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals("Bulk add failed", message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = BulkDocumentRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "failed to parse field [expirationDate] of type [date]"
-	)
 	@Test
 	public void testAddDocumentsBulkExecutor() {
-		List<Document> documents = new ArrayList<>();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		Document document = new DocumentImpl();
+			List<Document> documents = new ArrayList<>();
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
+			Document document = new DocumentImpl();
 
-		documents.add(document);
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
 
-		IndexWriter indexWriter = getIndexWriter();
+			documents.add(document);
 
-		try {
-			indexWriter.addDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.addDocuments(createSearchContext(), documents);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains(
+						"failed to parse field [expirationDate] of type " +
+							"[date] in document with id")),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "no such index"
-	)
 	@Test
 	public void testCommit() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexWriter.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(1);
+			SearchContext searchContext = new SearchContext();
 
-		IndexWriter indexWriter = getIndexWriter();
+			searchContext.setCompanyId(1);
 
-		try {
-			indexWriter.commit(searchContext);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.commit(searchContext);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals(
+					"[es/indices.refresh] failed: " +
+						"[index_not_found_exception] no such index [1]",
+					message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
@@ -152,100 +180,131 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.INFO, expectedLog = "no such index"
-	)
 	@Test
 	public void testDeleteDocumentInfoLevel() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexWriter.class.getName(),
+				LoggerTestUtil.INFO)) {
 
-		searchContext.setCompanyId(1);
+			String uid = "1";
 
-		IndexWriter indexWriter = getIndexWriter();
+			SearchContext searchContext = new SearchContext();
 
-		try {
-			indexWriter.deleteDocument(searchContext, "1");
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			searchContext.setCompanyId(1);
+
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.deleteDocument(searchContext, uid);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains(
+						StringBundler.concat(
+							"[es/delete] failed: [index_not_found_exception] ",
+							"no such index [", uid, "]"))),
+				logCapture, LoggerTestUtil.INFO);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Bulk delete failed"
-	)
 	@Test
 	public void testDeleteDocuments() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexWriter.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(1);
+			SearchContext searchContext = new SearchContext();
 
-		List<String> uids = new ArrayList<>();
+			searchContext.setCompanyId(1);
 
-		uids.add("1");
+			List<String> uids = new ArrayList<>();
 
-		IndexWriter indexWriter = getIndexWriter();
+			uids.add("1");
 
-		try {
-			indexWriter.deleteDocuments(searchContext, uids);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.deleteDocuments(searchContext, uids);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals("Bulk delete failed", message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = BulkDocumentRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "no such index"
-	)
 	@Test
 	public void testDeleteDocumentsBulkExecutor() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(1);
+			String uid = "1";
 
-		List<String> uids = new ArrayList<>();
+			SearchContext searchContext = new SearchContext();
 
-		uids.add("1");
+			searchContext.setCompanyId(1);
 
-		IndexWriter indexWriter = getIndexWriter();
+			List<String> uids = new ArrayList<>();
 
-		try {
-			indexWriter.deleteDocuments(searchContext, uids);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			uids.add(uid);
+
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.deleteDocuments(searchContext, uids);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains("no such index [" + uid + "]")),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "no such index"
-	)
 	@Test
 	public void testDeleteEntityDocuments() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexWriter.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(1);
+			SearchContext searchContext = new SearchContext();
 
-		IndexWriter indexWriter = getIndexWriter();
+			searchContext.setCompanyId(1);
 
-		try {
-			indexWriter.deleteEntityDocuments(searchContext, "test");
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.deleteEntityDocuments(searchContext, "test");
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals(
+					"[es/delete_by_query] failed: " +
+						"[index_not_found_exception] no such index [1]",
+					message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
@@ -292,106 +351,135 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 		indexWriter.partiallyUpdateDocuments(createSearchContext(), documents);
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "Update failed"
-	)
 	@Test
 	public void testUpdateDocument() {
-		Document document = new DocumentImpl();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexWriter.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			Document document = new DocumentImpl();
 
-		IndexWriter indexWriter = getIndexWriter();
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, "1");
 
-		try {
-			indexWriter.updateDocument(createSearchContext(), document);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.updateDocument(createSearchContext(), document);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals("Update failed", message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = BulkDocumentRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "failed to parse field [expirationDate] of type [date]"
-	)
 	@Test
 	public void testUpdateDocumentBulkExecutor() {
-		Document document = new DocumentImpl();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			String uid = "1";
 
-		IndexWriter indexWriter = getIndexWriter();
+			Document document = new DocumentImpl();
 
-		try {
-			indexWriter.updateDocument(createSearchContext(), document);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, uid);
+
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.updateDocument(createSearchContext(), document);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains(
+						StringBundler.concat(
+							"failed to parse field [expirationDate] of type ",
+							"[date] in document with id '", uid, "'."))),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = ElasticsearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Bulk update failed"
-	)
 	@Test
 	public void testUpdateDocuments() {
-		List<Document> documents = new ArrayList<>();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				ElasticsearchIndexWriter.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		Document document = new DocumentImpl();
+			List<Document> documents = new ArrayList<>();
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			Document document = new DocumentImpl();
 
-		documents.add(document);
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, "1");
 
-		IndexWriter indexWriter = getIndexWriter();
+			documents.add(document);
 
-		try {
-			indexWriter.updateDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.updateDocuments(createSearchContext(), documents);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals("Bulk update failed", message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = BulkDocumentRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "failed to parse field [expirationDate] of type [date]"
-	)
 	@Test
 	public void testUpdateDocumentsBulkExecutor() {
-		List<Document> documents = new ArrayList<>();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		Document document = new DocumentImpl();
+			String uid = "1";
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			List<Document> documents = new ArrayList<>();
 
-		documents.add(document);
+			Document document = new DocumentImpl();
 
-		IndexWriter indexWriter = getIndexWriter();
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, uid);
 
-		try {
-			indexWriter.updateDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			documents.add(document);
+
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.updateDocuments(createSearchContext(), documents);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message.contains(
+						StringBundler.concat(
+							"failed to parse field [expirationDate] of type ",
+							"[date] in document with id '", uid, "'."))),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
@@ -412,6 +500,19 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 		).elasticsearchFixture(
 			new ElasticsearchFixture(createElasticsearchConnectionFixture())
 		).build();
+	}
+
+	private void _assertLogCapture(
+		Consumer<String> consumer, LogCapture logCapture, String logLevel) {
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+		LogEntry logEntry = logEntries.get(0);
+
+		Assert.assertEquals(logLevel, logEntry.getPriority());
+		consumer.accept(logEntry.getMessage());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.search.elasticsearch8.internal.logging;
 
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -204,11 +206,12 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 			}
 
 			_assertLogCapture(
-				message -> Assert.assertTrue(
-					message.contains(
-						StringBundler.concat(
-							"[es/delete] failed: [index_not_found_exception] ",
-							"no such index [", uid, "]"))),
+				message -> Assert.assertEquals(
+					StringBundler.concat(
+						ElasticsearchException.class.getName(),
+						": [es/delete] failed: [index_not_found_exception] no ",
+						"such index [", uid, "]"),
+					message),
 				logCapture, LoggerTestUtil.INFO);
 		}
 	}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -179,7 +179,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 		IndexWriter indexWriter = getIndexWriter();
 
 		try {
-			indexWriter.deleteDocument(searchContext, "1");
+			indexWriter.deleteDocument(searchContext, _UID);
 		}
 		catch (SearchException searchException) {
 			if (_log.isDebugEnabled()) {
@@ -232,7 +232,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 			List<String> uids = new ArrayList<>();
 
-			uids.add("1");
+			uids.add(_UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -320,7 +320,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 	public void testPartiallyUpdateDocument() throws SearchException {
 		Document document = new DocumentImpl();
 
-		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.UID, _UID);
 
 		IndexWriter indexWriter = getIndexWriter();
 
@@ -333,7 +333,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 		List<Document> documents = new ArrayList<>();
 
-		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.UID, _UID);
 
 		documents.add(document);
 
@@ -350,7 +350,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 		List<Document> documents = new ArrayList<>();
 
-		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.UID, _UID);
 
 		documents.add(document);
 
@@ -368,7 +368,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 			Document document = new DocumentImpl();
 
 			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -432,7 +432,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 			Document document = new DocumentImpl();
 
 			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.UID, _UID);
 
 			documents.add(document);
 

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -56,15 +56,18 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 				ElasticsearchIndexWriter.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
+			String expectedMessage =
+				"failed to parse field [expirationDate] of type [date] in " +
+					"document with id";
+
 			addDocument(
 				DocumentCreationHelpers.singleKeyword(
 					Field.EXPIRATION_DATE, "text"));
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains(
-						"failed to parse field [expirationDate] of type " +
-							"[date] in document with id")),
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
@@ -106,6 +109,10 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
+			String expectedMessage =
+				"failed to parse field [expirationDate] of type [date] in " +
+					"document with id";
+
 			List<Document> documents = new ArrayList<>();
 
 			Document document = new DocumentImpl();
@@ -127,9 +134,8 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains(
-						"failed to parse field [expirationDate] of type " +
-							"[date] in document with id")),
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
@@ -251,6 +257,8 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
+			String expectedMessage = "no such index [" + _UID + "]";
+
 			SearchContext searchContext = new SearchContext();
 
 			searchContext.setCompanyId(1);
@@ -272,7 +280,8 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains("no such index [" + _UID + "]")),
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
@@ -384,6 +393,10 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
+			String expectedMessage = StringBundler.concat(
+				"failed to parse field [expirationDate] of type [date] in ",
+				"document with id '", _UID, "'.");
+
 			Document document = new DocumentImpl();
 
 			document.addKeyword(Field.EXPIRATION_DATE, "text");
@@ -402,10 +415,8 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains(
-						StringBundler.concat(
-							"failed to parse field [expirationDate] of type ",
-							"[date] in document with id '", _UID, "'."))),
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
@@ -448,6 +459,10 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
+			String expectedMessage = StringBundler.concat(
+				"failed to parse field [expirationDate] of type [date] in ",
+				"document with id '", _UID, "'.");
+
 			List<Document> documents = new ArrayList<>();
 
 			Document document = new DocumentImpl();
@@ -470,10 +485,8 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains(
-						StringBundler.concat(
-							"failed to parse field [expirationDate] of type ",
-							"[date] in document with id '", _UID, "'."))),
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -188,8 +188,6 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 				ElasticsearchIndexWriter.class.getName(),
 				LoggerTestUtil.INFO)) {
 
-			String uid = "1";
-
 			SearchContext searchContext = new SearchContext();
 
 			searchContext.setCompanyId(1);
@@ -197,7 +195,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 			IndexWriter indexWriter = getIndexWriter();
 
 			try {
-				indexWriter.deleteDocument(searchContext, uid);
+				indexWriter.deleteDocument(searchContext, _UID);
 			}
 			catch (SearchException searchException) {
 				if (_log.isDebugEnabled()) {
@@ -210,7 +208,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 					StringBundler.concat(
 						ElasticsearchException.class.getName(),
 						": [es/delete] failed: [index_not_found_exception] no ",
-						"such index [", uid, "]"),
+						"such index [", _UID, "]"),
 					message),
 				logCapture, LoggerTestUtil.INFO);
 		}
@@ -253,15 +251,13 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
-			String uid = "1";
-
 			SearchContext searchContext = new SearchContext();
 
 			searchContext.setCompanyId(1);
 
 			List<String> uids = new ArrayList<>();
 
-			uids.add(uid);
+			uids.add(_UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -276,7 +272,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
-					message.contains("no such index [" + uid + "]")),
+					message.contains("no such index [" + _UID + "]")),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
@@ -388,12 +384,10 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
-			String uid = "1";
-
 			Document document = new DocumentImpl();
 
 			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, uid);
+			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -411,7 +405,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 					message.contains(
 						StringBundler.concat(
 							"failed to parse field [expirationDate] of type ",
-							"[date] in document with id '", uid, "'."))),
+							"[date] in document with id '", _UID, "'."))),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
@@ -454,14 +448,12 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
 
-			String uid = "1";
-
 			List<Document> documents = new ArrayList<>();
 
 			Document document = new DocumentImpl();
 
 			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, uid);
+			document.addKeyword(Field.UID, _UID);
 
 			documents.add(document);
 
@@ -481,7 +473,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 					message.contains(
 						StringBundler.concat(
 							"failed to parse field [expirationDate] of type ",
-							"[date] in document with id '", uid, "'."))),
+							"[date] in document with id '", _UID, "'."))),
 				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
@@ -517,6 +509,8 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 		Assert.assertEquals(logLevel, logEntry.getPriority());
 		consumer.accept(logEntry.getMessage());
 	}
+
+	private static final String _UID = "1";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ElasticsearchIndexWriterLogExceptionsOnlyTest.class);

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
@@ -92,7 +92,7 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 			_searchEngineAdapter.execute(
 				new CountSearchRequest() {
 					{
-						setIndexNames("_all");
+						setIndexNames(_INDEX_NAME);
 						setQuery(new MatchAllQuery());
 					}
 				});
@@ -102,9 +102,11 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 			Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
 
 			_assertLogEntry(
-				logEntries.get(0), "Stack trace for [_all]:", LoggerTestUtil.INFO);
+				logEntries.get(0), "Stack trace for [" + _INDEX_NAME + "]:",
+				LoggerTestUtil.INFO);
 			_assertLogEntry(
-				logEntries.get(1), "Search request string for [_all]:",
+				logEntries.get(1),
+				"Search request string for [" + _INDEX_NAME + "]:",
 				LoggerTestUtil.DEBUG);
 			_assertLogEntry(
 				logEntries.get(2), "The search engine processed the request in",
@@ -124,7 +126,7 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 						addSearchSearchRequest(
 							new SearchSearchRequest() {
 								{
-									setIndexNames("_all");
+									setIndexNames(_INDEX_NAME);
 									setQuery(new MatchAllQuery());
 								}
 							});
@@ -150,7 +152,7 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 			_searchEngineAdapter.execute(
 				new SearchSearchRequest() {
 					{
-						setIndexNames("_all");
+						setIndexNames(_INDEX_NAME);
 						setQuery(new MatchAllQuery());
 					}
 				});
@@ -160,9 +162,11 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 			Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
 
 			_assertLogEntry(
-				logEntries.get(0), "Stack trace for [_all]:", LoggerTestUtil.INFO);
+				logEntries.get(0), "Stack trace for [" + _INDEX_NAME + "]:",
+				LoggerTestUtil.INFO);
 			_assertLogEntry(
-				logEntries.get(1), "Search request string for [_all]:",
+				logEntries.get(1),
+				"Search request string for [" + _INDEX_NAME + "]:",
 				LoggerTestUtil.DEBUG);
 			_assertLogEntry(
 				logEntries.get(2), "The search engine processed the request in",
@@ -197,6 +201,8 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 				}
 			});
 	}
+
+	private static final String _INDEX_NAME = "_all";
 
 	private static ElasticsearchConnectionFixture
 		_elasticsearchConnectionFixture;

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
@@ -151,12 +151,12 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 	private void _assertLogEntry(
 		LogEntry logEntry, String expectedMessage, String logLevel) {
 
+		String message = logEntry.getMessage();
+
 		Assert.assertEquals(logLevel, logEntry.getPriority());
 		Assert.assertTrue(
-			logEntry.getMessage(
-			).startsWith(
-				expectedMessage
-			));
+			message + " does not start with " + expectedMessage,
+			message.startsWith(expectedMessage));
 	}
 
 	private void _assertSearchRequestExecutorLogEntries(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
@@ -20,10 +20,15 @@ import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.search.CountSearchRequest;
 import com.liferay.portal.search.engine.adapter.search.MultisearchSearchRequest;
 import com.liferay.portal.search.engine.adapter.search.SearchSearchRequest;
-import com.liferay.portal.search.test.util.logging.ExpectedLog;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.List;
+
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -78,57 +83,102 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 			_elasticsearchEngineAdapterFixture.getSearchEngineAdapter();
 	}
 
-	@ExpectedLog(
-		expectedClass = CountSearchRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "The search engine processed"
-	)
 	@Test
 	public void testCountSearchRequestExecutorLogs() {
-		_searchEngineAdapter.execute(
-			new CountSearchRequest() {
-				{
-					setIndexNames("_all");
-					setQuery(new MatchAllQuery());
-				}
-			});
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				CountSearchRequestExecutor.class.getName(),
+				LoggerTestUtil.DEBUG)) {
+
+			_searchEngineAdapter.execute(
+				new CountSearchRequest() {
+					{
+						setIndexNames("_all");
+						setQuery(new MatchAllQuery());
+					}
+				});
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
+
+			_assertLogEntry(
+				logEntries.get(0), "Stack trace for [_all]:", LoggerTestUtil.INFO);
+			_assertLogEntry(
+				logEntries.get(1), "Search request string for [_all]:",
+				LoggerTestUtil.DEBUG);
+			_assertLogEntry(
+				logEntries.get(2), "The search engine processed the request in",
+				LoggerTestUtil.DEBUG);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = MultisearchSearchRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "The search engine processed"
-	)
 	@Test
 	public void testMultisearchSearchRequestExecutorLogs() {
-		_searchEngineAdapter.execute(
-			new MultisearchSearchRequest() {
-				{
-					addSearchSearchRequest(
-						new SearchSearchRequest() {
-							{
-								setIndexNames("_all");
-								setQuery(new MatchAllQuery());
-							}
-						});
-				}
-			});
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				MultisearchSearchRequestExecutor.class.getName(),
+				LoggerTestUtil.DEBUG)) {
+
+			_searchEngineAdapter.execute(
+				new MultisearchSearchRequest() {
+					{
+						addSearchSearchRequest(
+							new SearchSearchRequest() {
+								{
+									setIndexNames("_all");
+									setQuery(new MatchAllQuery());
+								}
+							});
+					}
+				});
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			_assertLogEntry(
+				logEntries.get(0), "The search engine processed",
+				LoggerTestUtil.DEBUG);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = SearchSearchRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.FINE,
-		expectedLog = "The search engine processed"
-	)
 	@Test
 	public void testSearchSearchRequestExecutorLogs() {
-		_searchEngineAdapter.execute(
-			new SearchSearchRequest() {
-				{
-					setIndexNames("_all");
-					setQuery(new MatchAllQuery());
-				}
-			});
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				SearchSearchRequestExecutor.class.getName(),
+				LoggerTestUtil.DEBUG)) {
+
+			_searchEngineAdapter.execute(
+				new SearchSearchRequest() {
+					{
+						setIndexNames("_all");
+						setQuery(new MatchAllQuery());
+					}
+				});
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
+
+			_assertLogEntry(
+				logEntries.get(0), "Stack trace for [_all]:", LoggerTestUtil.INFO);
+			_assertLogEntry(
+				logEntries.get(1), "Search request string for [_all]:",
+				LoggerTestUtil.DEBUG);
+			_assertLogEntry(
+				logEntries.get(2), "The search engine processed the request in",
+				LoggerTestUtil.DEBUG);
+		}
+	}
+
+	private void _assertLogEntry(
+		LogEntry logEntry, String expectedMessage, String logLevel) {
+
+		Assert.assertEquals(logLevel, logEntry.getPriority());
+		Assert.assertTrue(
+			logEntry.getMessage(
+			).startsWith(
+				expectedMessage
+			));
 	}
 
 	private void _waitForElasticsearchToStart(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
@@ -97,20 +97,7 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 					}
 				});
 
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
-
-			_assertLogEntry(
-				logEntries.get(0), "Stack trace for [" + _INDEX_NAME + "]:",
-				LoggerTestUtil.INFO);
-			_assertLogEntry(
-				logEntries.get(1),
-				"Search request string for [" + _INDEX_NAME + "]:",
-				LoggerTestUtil.DEBUG);
-			_assertLogEntry(
-				logEntries.get(2), "The search engine processed the request in",
-				LoggerTestUtil.DEBUG);
+			_assertSearchRequestExecutorLogEntries(logCapture.getLogEntries());
 		}
 	}
 
@@ -157,20 +144,7 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 					}
 				});
 
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
-
-			_assertLogEntry(
-				logEntries.get(0), "Stack trace for [" + _INDEX_NAME + "]:",
-				LoggerTestUtil.INFO);
-			_assertLogEntry(
-				logEntries.get(1),
-				"Search request string for [" + _INDEX_NAME + "]:",
-				LoggerTestUtil.DEBUG);
-			_assertLogEntry(
-				logEntries.get(2), "The search engine processed the request in",
-				LoggerTestUtil.DEBUG);
+			_assertSearchRequestExecutorLogEntries(logCapture.getLogEntries());
 		}
 	}
 
@@ -183,6 +157,23 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 			).startsWith(
 				expectedMessage
 			));
+	}
+
+	private void _assertSearchRequestExecutorLogEntries(
+		List<LogEntry> logEntries) {
+
+		Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
+
+		_assertLogEntry(
+			logEntries.get(0), "Stack trace for [" + _INDEX_NAME + "]:",
+			LoggerTestUtil.INFO);
+		_assertLogEntry(
+			logEntries.get(1),
+			"Search request string for [" + _INDEX_NAME + "]:",
+			LoggerTestUtil.DEBUG);
+		_assertLogEntry(
+			logEntries.get(2), "The search engine processed the request in",
+			LoggerTestUtil.DEBUG);
 	}
 
 	private void _waitForElasticsearchToStart(


### PR DESCRIPTION
@shuyangzhou 
- I avoided using org.hamcrest in favor of Consumer<String> based on your previous feedback.
- In ElasticsearchIndexWriterExceptionsTest, I added a try (LogCapture logCapture...) block for some tests that were printing errors to the console, to prevent these errors from showing up.
- I also extracted constant values used in the tests, specifically UID and _INDEX_NAME.