### PR TITLE
LPD-90507 Restore reverse-sort and warning on duplicate unique finder

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/UniquePersistenceFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/UniquePersistenceFinder.java
@@ -6,13 +6,18 @@
 package com.liferay.portal.kernel.service.persistence.impl;
 
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
 import com.liferay.portal.kernel.dao.orm.Query;
 import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.util.StringUtil;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -91,6 +96,26 @@ public class UniquePersistenceFinder<T extends BaseModel<T>>
 						}
 					}
 					else {
+						if (list.size() > 1) {
+							Collections.sort(list, Collections.reverseOrder());
+
+							if (_log.isWarnEnabled()) {
+								Class<T> modelClass =
+									basePersistenceImpl.getModelClass();
+
+								_log.warn(
+									StringBundler.concat(
+										"Unique finder on ",
+										modelClass.getName(), " with values (",
+										StringUtil.merge(values),
+										") yields a result set with more than ",
+										"1 result. This violates the logical ",
+										"unique restriction. There is no ",
+										"order guarantee on which result is ",
+										"returned by this finder."));
+							}
+						}
+
 						T entity = list.get(0);
 
 						result = entity;
@@ -113,6 +138,9 @@ public class UniquePersistenceFinder<T extends BaseModel<T>>
 			return (T)result;
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UniquePersistenceFinder.class);
 
 	private final FinderPath _fetchPath;
 


### PR DESCRIPTION
Hi Shuyang, DefaultOrderEntityTest failed caused by` LPD-87435 Modeling Finder to extract business logic out of generated persistence code.`

I am not sure if you remove this part on purpose or not, just want to bring this up. The fix here is just bring back the old behavior.  

The root cause is actually long history. We treat a finder to be unique when generating finder by `!isCollection() || isUnique()` while generating unique index only respect `isUnique()`, making the non-collection finder which did not mark as unique does not have unique index, and then we may have duplicated entries in database.


